### PR TITLE
feat: make settings discoverable from main UI

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -311,6 +311,12 @@
       <span class="badge">{ $rvReservationStore.parkingLocations.length } sites</span>
       <span class="badge save-badge" aria-live="polite">{autosaveStatus}</span>
       <button type="button" class="save-btn" on:click={saveNow}>Save</button>
+      <a href="/admin" class="settings-link" title="Settings" aria-label="Settings" data-testid="settings-link">
+        <svg class="settings-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" width="20" height="20">
+          <circle cx="12" cy="12" r="3" />
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+        </svg>
+      </a>
     </div>
   </header>
 
@@ -466,6 +472,31 @@
     display: flex;
     gap: 0.35rem;
     align-items: center;
+  }
+
+  .settings-link {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    border: 1px solid #d9e1ec;
+    background: #f6f9fd;
+    color: #5c6c80;
+    text-decoration: none;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    flex-shrink: 0;
+  }
+
+  .settings-link:hover {
+    color: #0a63e0;
+    border-color: #0a63e0;
+    background: #edf3fd;
+  }
+
+  .settings-icon {
+    display: block;
   }
 
   .daily-summary {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -85,16 +85,16 @@
 </script>
 
 <svelte:head>
-  <title>Admin | {$siteSettingsStore.siteName}</title>
-  <meta name="description" content="Admin settings for RV Reservation Demo." />
+  <title>Settings | {$siteSettingsStore.siteName}</title>
+  <meta name="description" content="Park settings for {$siteSettingsStore.siteName}." />
 </svelte:head>
 
 <div class="admin-shell">
   <header class="admin-header">
-    <p class="eyebrow">Settings</p>
-    <h1>Admin</h1>
+    <a href="/" class="back-link" data-testid="back-to-schedule">&larr; Back to Schedule</a>
+    <h1>Park Settings</h1>
     <p>
-      This page is intentionally not linked from the main UI. It controls local settings only.
+      Manage your park name and admin passcode. Protected settings require a passcode.
     </p>
   </header>
 
@@ -175,13 +175,17 @@
     padding: 1rem;
   }
 
-  .eyebrow {
-    margin: 0;
-    color: #466684;
-    font-weight: 700;
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+  .back-link {
+    display: inline-block;
+    margin: 0 0 0.3rem;
+    color: #0c5fdb;
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
   }
 
   h1,

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -10,6 +10,47 @@ test.describe('Admin page', () => {
 		await clearStorage(page);
 	});
 
+	test('gear icon on main page navigates to settings', async ({ page }) => {
+		await page.goto('/');
+
+		// Gear icon should be visible
+		const settingsLink = page.locator('[data-testid="settings-link"]');
+		await expect(settingsLink).toBeVisible();
+		await expect(settingsLink).toHaveAttribute('href', '/admin');
+		await expect(settingsLink).toHaveAttribute('aria-label', 'Settings');
+
+		// Click navigates to /admin
+		await settingsLink.click();
+		await expect(page).toHaveURL(/\/admin$/);
+		await expect(page.locator('h1')).toHaveText('Park Settings');
+	});
+
+	test('admin page has back link to main schedule', async ({ page }) => {
+		await page.goto('/admin');
+
+		const backLink = page.locator('[data-testid="back-to-schedule"]');
+		await expect(backLink).toBeVisible();
+		await expect(backLink).toHaveAttribute('href', '/');
+
+		// Click navigates back to main page
+		await backLink.click();
+		await expect(page).toHaveURL(/\/$/);
+		await expect(page.locator('#working-sheet-title')).toHaveText('Working Sheet');
+	});
+
+	test('admin page does not describe itself as hidden', async ({ page }) => {
+		await page.goto('/admin');
+
+		// Should say "Park Settings", not "Admin"
+		await expect(page.locator('h1')).toHaveText('Park Settings');
+
+		// Should not contain "hidden" language
+		const headerText = await page.locator('.admin-header').textContent();
+		expect(headerText?.toLowerCase()).not.toContain('hidden');
+		expect(headerText?.toLowerCase()).not.toContain('secret');
+		expect(headerText?.toLowerCase()).not.toContain('not linked');
+	});
+
 	test('set initial passcode and change site name', async ({ page }) => {
 		await page.goto('/admin');
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -9,6 +9,6 @@ test.describe('Smoke tests', () => {
 
 	test('admin page loads', async ({ page }) => {
 		await page.goto('/admin');
-		await expect(page.locator('h1')).toHaveText('Admin');
+		await expect(page.locator('h1')).toHaveText('Park Settings');
 	});
 });


### PR DESCRIPTION
## Summary
- Add gear icon in header linking to /admin settings page
- Remove "hidden route" language from admin page
- Add back-link from settings to main schedule
- Preserve passcode protection for protected settings

## Test plan
- [ ] Gear icon visible on main page and navigates to /admin
- [ ] Admin page no longer describes itself as hidden
- [ ] Back-link returns to main schedule
- [ ] Passcode protection still works
- [ ] Playwright e2e tests pass
- [ ] `npm run check` and `npm run build` pass

> Note: Gear icon placement may need adjustment after issue 004 (toolbar) merges.