### PR TITLE
feat: streamline reservation modal for speed and accessibility

### DIFF
--- a/src/lib/components/ReservationModal.svelte
+++ b/src/lib/components/ReservationModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, afterUpdate } from 'svelte';
+  import { diffDays } from '$lib/date';
   import { MAX_RESERVATION_NOTES_LENGTH } from '$lib/reservations';
   import { STATUS_COLORS, STATUS_LABELS } from '$lib/domain/reservations/status';
   import { RESERVATION_STATUSES, type ReservationFormValues, type ReservationStatus } from '$lib/types';
@@ -18,6 +19,8 @@
     status: 'reserved'
   };
   export let errors: string[] = [];
+  /** Element that triggered the modal open, used for focus return on close. */
+  export let triggerElement: HTMLElement | null = null;
 
   const dispatch = createEventDispatcher<{
     save: ReservationFormValues;
@@ -28,10 +31,41 @@
   const emptyExtras = { phoneNumber: '', notes: '' };
   let form: ReservationFormValues = { ...emptyExtras, ...draft };
   let confirmingDelete = false;
+  let guestNameInput: HTMLInputElement | null = null;
+  let wasOpen = false;
+
+  /** Computed nights display */
+  $: nightsCount = (form.startDate && form.endDate)
+    ? diffDays(form.startDate, form.endDate)
+    : null;
+  $: nightsLabel = nightsCount !== null && nightsCount > 0
+    ? `${nightsCount} night${nightsCount === 1 ? '' : 's'}`
+    : null;
 
   $: if (open) {
     form = { ...emptyExtras, ...draft };
     confirmingDelete = false;
+  }
+
+  afterUpdate(() => {
+    // Focus guest name input when modal just opened
+    if (open && !wasOpen && guestNameInput) {
+      guestNameInput.focus();
+    }
+    wasOpen = open;
+  });
+
+  function returnFocusToTrigger(): void {
+    if (triggerElement) {
+      requestAnimationFrame(() => {
+        triggerElement?.focus();
+      });
+    }
+  }
+
+  function handleClose(): void {
+    dispatch('cancel');
+    returnFocusToTrigger();
   }
 
   function handleSubmit(): void {
@@ -40,7 +74,7 @@
 
   function handleOverlayClick(event: MouseEvent): void {
     if (event.currentTarget === event.target) {
-      dispatch('cancel');
+      handleClose();
     }
   }
 
@@ -50,7 +84,7 @@
       if (confirmingDelete) {
         confirmingDelete = false;
       } else {
-        dispatch('cancel');
+        handleClose();
       }
     }
   }
@@ -58,6 +92,7 @@
   function handleDeleteClick(): void {
     if (confirmingDelete) {
       dispatch('delete', { index: form.index as number });
+      returnFocusToTrigger();
     } else {
       confirmingDelete = true;
     }
@@ -70,10 +105,19 @@
   <div class="modal-backdrop" role="presentation" on:click={handleOverlayClick}>
     <section class="modal" role="dialog" aria-modal="true" aria-labelledby="reservation-modal-title">
       <header class="modal-header">
-        <h2 id="reservation-modal-title">{mode === 'create' ? 'New Reservation' : 'Edit Reservation'}</h2>
-        {#if mode === 'edit' && typeof form.index === 'number'}
-          <p class="meta">Reservation #{form.index}</p>
-        {/if}
+        <div class="modal-header-text">
+          <h2 id="reservation-modal-title">{mode === 'create' ? 'New Reservation' : 'Edit Reservation'}</h2>
+          {#if mode === 'edit' && typeof form.index === 'number'}
+            <p class="meta">Reservation #{form.index}</p>
+          {/if}
+        </div>
+        <button
+          type="button"
+          class="close-button"
+          aria-label="Close modal"
+          data-testid="modal-close-button"
+          on:click={handleClose}
+        >&times;</button>
       </header>
 
       {#if errors.length > 0}
@@ -88,27 +132,39 @@
       {/if}
 
       <form class="modal-form" on:submit|preventDefault={handleSubmit}>
+        <!-- 1. Guest Name (autofocused) -->
         <label>
           <span>Name</span>
-          <input bind:value={form.name} type="text" placeholder="Guest name" required maxlength="80" />
+          <input
+            bind:this={guestNameInput}
+            bind:value={form.name}
+            type="text"
+            placeholder="Guest name"
+            required
+            maxlength="80"
+          />
         </label>
 
-        <label>
-          <span>Phone Number</span>
-          <input bind:value={form.phoneNumber} type="tel" placeholder="(555) 555-5555" maxlength="40" />
-        </label>
-
+        <!-- 2. Arrival / Departure dates -->
         <div class="row-2">
           <label>
-            <span>Start Date</span>
+            <span>Arrival</span>
             <input bind:value={form.startDate} type="date" required />
           </label>
           <label>
-            <span>End Date</span>
+            <span>Departure</span>
             <input bind:value={form.endDate} type="date" required />
           </label>
         </div>
 
+        <!-- Nights display -->
+        {#if nightsLabel}
+          <div class="nights-display" data-testid="nights-display" aria-live="polite">
+            {nightsLabel}
+          </div>
+        {/if}
+
+        <!-- 3. Site (parking location) -->
         <label>
           <span>Site</span>
           <select bind:value={form.parkingLocation} required>
@@ -134,6 +190,13 @@
           </div>
         </label>
 
+        <!-- 5. Phone Number -->
+        <label>
+          <span>Phone Number</span>
+          <input bind:value={form.phoneNumber} type="tel" placeholder="(555) 555-5555" maxlength="40" />
+        </label>
+
+        <!-- 6. Notes -->
         <label>
           <span class="notes-label-row">
             <span>Notes</span>
@@ -148,17 +211,21 @@
         </label>
 
         <footer class="modal-actions">
-          <button type="submit" class="primary">Save</button>
-          <button type="button" on:click={() => dispatch('cancel')}>Cancel</button>
           {#if mode === 'edit' && typeof form.index === 'number'}
-            <button
-              type="button"
-              class={confirmingDelete ? 'danger confirming' : 'danger'}
-              on:click={handleDeleteClick}
-            >
-              {confirmingDelete ? 'Confirm Delete?' : 'Delete'}
-            </button>
+            <div class="delete-zone">
+              <button
+                type="button"
+                class={confirmingDelete ? 'danger confirming' : 'danger'}
+                on:click={handleDeleteClick}
+              >
+                {confirmingDelete ? 'Confirm Delete?' : 'Delete'}
+              </button>
+            </div>
           {/if}
+          <div class="save-cancel">
+            <button type="button" on:click={handleClose}>Cancel</button>
+            <button type="submit" class="primary">Save</button>
+          </div>
         </footer>
       </form>
     </section>
@@ -188,10 +255,17 @@
 
   .modal-header {
     display: flex;
-    align-items: baseline;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 1rem;
     margin-bottom: 0.75rem;
+  }
+
+  .modal-header-text {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    flex: 1;
   }
 
   h2 {
@@ -203,6 +277,27 @@
     margin: 0;
     color: #455566;
     font-size: 0.85rem;
+  }
+
+  .close-button {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: #6b7a8d;
+    cursor: pointer;
+    padding: 0.15rem 0.4rem;
+    border-radius: 6px;
+    min-height: 32px;
+    min-width: 32px;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+  }
+
+  .close-button:hover {
+    background: #f0f3f7;
+    color: #1b304a;
   }
 
   .error-box {
@@ -228,6 +323,17 @@
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.75rem;
+  }
+
+  .nights-display {
+    font-size: 0.88rem;
+    color: #3d5a78;
+    font-weight: 600;
+    padding: 0.3rem 0.6rem;
+    background: #f0f6ff;
+    border: 1px solid #d0dfef;
+    border-radius: 8px;
+    text-align: center;
   }
 
   label {
@@ -299,9 +405,20 @@
 
   .modal-actions {
     display: flex;
+    justify-content: space-between;
+    align-items: center;
     gap: 0.55rem;
-    justify-content: flex-end;
     margin-top: 0.25rem;
+  }
+
+  .delete-zone {
+    flex-shrink: 0;
+  }
+
+  .save-cancel {
+    display: flex;
+    gap: 0.55rem;
+    margin-left: auto;
   }
 
   button {
@@ -340,11 +457,22 @@
 
     .modal-actions {
       flex-wrap: wrap;
-      justify-content: stretch;
     }
 
-    .modal-actions button {
-      flex: 1 1 30%;
+    .delete-zone {
+      width: 100%;
+    }
+
+    .delete-zone button {
+      width: 100%;
+    }
+
+    .save-cancel {
+      width: 100%;
+    }
+
+    .save-cancel button {
+      flex: 1;
     }
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -40,6 +40,7 @@
   let modalOpen = false;
   let modalMode: 'create' | 'edit' = 'create';
   let modalErrors: string[] = [];
+  let modalTriggerElement: HTMLElement | null = null;
   let modalDraft: ReservationFormValues = {
     name: '',
     phoneNumber: '',
@@ -117,7 +118,8 @@
     gridScroller?.scrollBy({ left: DATE_COLUMN_WIDTH * 7 * direction, behavior: 'smooth' });
   }
 
-  function openModalForCell(parkingLocation: string, dateIso: string): void {
+  function openModalForCell(parkingLocation: string, dateIso: string, event?: MouseEvent): void {
+    modalTriggerElement = (event?.currentTarget as HTMLElement) ?? null;
     const reservation = occupancyMap.get(buildCellId(parkingLocation, dateIso));
 
     if (reservation) {
@@ -373,7 +375,7 @@
                   <td
                     class={`grid-cell ${reservation ? 'occupied' : 'empty'} ${dateIso === todayIso ? 'today' : ''}`}
                     style={reservation ? `background: ${STATUS_BACKGROUND_COLORS[reservation.status]}; border-left: 3px solid ${STATUS_COLORS[reservation.status]};` : ''}
-                    on:click={() => openModalForCell(location, dateIso)}
+                    on:click={(e) => openModalForCell(location, dateIso, e)}
                     title={getReservationCellTitle(location, dateIso, reservation)}
                   >
                     {#if reservation}
@@ -402,6 +404,7 @@
   draft={modalDraft}
   errors={modalErrors}
   parkingLocations={$rvReservationStore.parkingLocations}
+  triggerElement={modalTriggerElement}
   on:save={handleModalSave}
   on:cancel={closeModal}
   on:delete={handleModalDelete}

--- a/tests/e2e/reservations.spec.ts
+++ b/tests/e2e/reservations.spec.ts
@@ -23,8 +23,8 @@ function getTodayIso(): string {
 
 const modal = (page: Page) => page.locator('.modal[role="dialog"]');
 
-/** Double-click a grid cell by locating the date column via data-date attribute. */
-async function dblclickCellAtDate(page: Page, dateIso: string, rowIndex = 0) {
+/** Click a grid cell by locating the date column via data-date attribute. */
+async function clickCellAtDate(page: Page, dateIso: string, rowIndex = 0) {
 	const colIndex = await page.evaluate((date) => {
 		const headers = document.querySelectorAll('th.date-header[data-date]');
 		for (let i = 0; i < headers.length; i++) {
@@ -36,7 +36,7 @@ async function dblclickCellAtDate(page: Page, dateIso: string, rowIndex = 0) {
 
 	const cell = page.locator('tbody tr').nth(rowIndex).locator('td.grid-cell').nth(colIndex);
 	await cell.scrollIntoViewIfNeeded();
-	await cell.dblclick();
+	await cell.click();
 }
 
 /** Create a reservation via UI and verify modal closes. */
@@ -44,7 +44,7 @@ async function createReservation(
 	page: Page,
 	opts: { name: string; startDate: string; endDate: string; rowIndex?: number }
 ) {
-	await dblclickCellAtDate(page, opts.startDate, opts.rowIndex ?? 0);
+	await clickCellAtDate(page, opts.startDate, opts.rowIndex ?? 0);
 	await expect(modal(page)).toBeVisible();
 
 	await modal(page).locator('input[placeholder="Guest name"]').fill(opts.name);
@@ -60,7 +60,7 @@ test.describe('Reservation CRUD', () => {
 		await resetApp(page);
 	});
 
-	test('create a reservation via double-click', async ({ page }) => {
+	test('create a reservation via click', async ({ page }) => {
 		const today = getTodayIso();
 		const endDate = offsetDate(3);
 
@@ -78,10 +78,10 @@ test.describe('Reservation CRUD', () => {
 
 		await createReservation(page, { name: 'Jane Smith', startDate: today, endDate });
 
-		// Find occupied cell, scroll to it, double-click to edit
+		// Find occupied cell, scroll to it, click to edit
 		const occupied = page.locator('.grid-cell.occupied').first();
 		await occupied.scrollIntoViewIfNeeded();
-		await occupied.dblclick();
+		await occupied.click();
 		await expect(modal(page)).toBeVisible();
 
 		await expect(modal(page).locator('#reservation-modal-title')).toHaveText('Edit Reservation');
@@ -102,9 +102,14 @@ test.describe('Reservation CRUD', () => {
 
 		const occupied = page.locator('.grid-cell.occupied').first();
 		await occupied.scrollIntoViewIfNeeded();
-		await occupied.dblclick();
+		await occupied.click();
 		await expect(modal(page)).toBeVisible();
 
+		// First click shows confirmation
+		await modal(page).locator('button.danger').click();
+		await expect(modal(page).locator('button.danger')).toContainText('Confirm Delete');
+
+		// Second click actually deletes
 		await modal(page).locator('button.danger').click();
 		await expect(modal(page)).not.toBeVisible();
 
@@ -118,8 +123,8 @@ test.describe('Reservation CRUD', () => {
 
 		await createReservation(page, { name: 'First Guest', startDate, endDate });
 
-		// Double-click an EMPTY cell in the same row (today, before the reservation)
-		await dblclickCellAtDate(page, getTodayIso(), 0);
+		// Click an EMPTY cell in the same row (today, before the reservation)
+		await clickCellAtDate(page, getTodayIso(), 0);
 		await expect(modal(page)).toBeVisible();
 
 		await modal(page).locator('input[placeholder="Guest name"]').fill('Overlapper');
@@ -136,6 +141,65 @@ test.describe('Reservation CRUD', () => {
 		// Modal stays open with error
 		await expect(modal(page).locator('.error-box')).toBeVisible();
 		await expect(modal(page).locator('.error-box')).toContainText('Overlap');
+	});
+});
+
+test.describe('Modal accessibility and UX', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('modal opens with focus on guest name field', async ({ page }) => {
+		const today = getTodayIso();
+		await clickCellAtDate(page, today, 0);
+		await expect(modal(page)).toBeVisible();
+
+		// Guest name input should be focused
+		const nameInput = modal(page).locator('input[placeholder="Guest name"]');
+		await expect(nameInput).toBeFocused();
+	});
+
+	test('close button dismisses modal', async ({ page }) => {
+		const today = getTodayIso();
+		await clickCellAtDate(page, today, 0);
+		await expect(modal(page)).toBeVisible();
+
+		// Click the X close button
+		await modal(page).locator('[data-testid="modal-close-button"]').click();
+		await expect(modal(page)).not.toBeVisible();
+	});
+
+	test('nights display shows correct count when both dates are set', async ({ page }) => {
+		const today = getTodayIso();
+		const endDate = offsetDate(5);
+		await clickCellAtDate(page, today, 0);
+		await expect(modal(page)).toBeVisible();
+
+		// Set dates
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+
+		// Nights display should show "5 nights"
+		const nightsDisplay = modal(page).locator('[data-testid="nights-display"]');
+		await expect(nightsDisplay).toBeVisible();
+		await expect(nightsDisplay).toHaveText('5 nights');
+	});
+
+	test('nights display updates when dates change', async ({ page }) => {
+		const today = getTodayIso();
+		await clickCellAtDate(page, today, 0);
+		await expect(modal(page)).toBeVisible();
+
+		// Set for 3 nights
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(offsetDate(3));
+
+		const nightsDisplay = modal(page).locator('[data-testid="nights-display"]');
+		await expect(nightsDisplay).toHaveText('3 nights');
+
+		// Change to 1 night
+		await modal(page).locator('input[type="date"]').nth(1).fill(offsetDate(1));
+		await expect(nightsDisplay).toHaveText('1 night');
 	});
 });
 


### PR DESCRIPTION
## Summary
- Add autofocus on guest name field when modal opens
- Add focus return to trigger element on modal close
- Add explicit close button (X) in modal header
- Reorder fields to match operator workflow
- Add "N nights" display when both dates are set
- Improve delete button layout and visual distinction

## Test plan
- [ ] Modal opens with focus on guest name
- [ ] Close button dismisses modal
- [ ] Focus returns to trigger element on close
- [ ] Nights display shows correct count
- [ ] Delete button visually distinct
- [ ] Playwright e2e tests pass (14/14)
- [ ] `npm run check` and `npm run build` pass

> Note: Color picker should become status dropdown after issue 010 merges.