### PR TITLE
feat: replace color picker with reservation status model

### DIFF
--- a/src/lib/application/use-cases/reservation-use-cases.ts
+++ b/src/lib/application/use-cases/reservation-use-cases.ts
@@ -63,7 +63,8 @@ export function createReservationUseCases(_repo: AppDataRepository): Reservation
 				startDate: form.startDate,
 				endDate: form.endDate,
 				parkingLocation: form.parkingLocation,
-				color: form.color
+				color: form.color,
+				status: form.status
 			};
 
 			const reservations = existing

--- a/src/lib/components/ReservationModal.svelte
+++ b/src/lib/components/ReservationModal.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import { MAX_RESERVATION_NOTES_LENGTH } from '$lib/reservations';
-  import { RESERVATION_COLORS, type ReservationFormValues } from '$lib/types';
+  import { STATUS_COLORS, STATUS_LABELS } from '$lib/domain/reservations/status';
+  import { RESERVATION_STATUSES, type ReservationFormValues, type ReservationStatus } from '$lib/types';
 
   export let open = false;
   export let mode: 'create' | 'edit' = 'create';
@@ -13,7 +14,8 @@
     startDate: '',
     endDate: '',
     parkingLocation: '',
-    color: 'blue'
+    color: 'blue',
+    status: 'reserved'
   };
   export let errors: string[] = [];
 
@@ -22,16 +24,6 @@
     cancel: void;
     delete: { index: number };
   }>();
-
-  const COLOR_SWATCHES: Record<string, string> = {
-    red: '#ffd9d9',
-    green: '#ddf7dd',
-    blue: '#d9ebff',
-    yellow: '#fff5c6',
-    pink: '#ffe0ef',
-    orange: '#ffe5cd',
-    purple: '#eadfff'
-  };
 
   const emptyExtras = { phoneNumber: '', notes: '' };
   let form: ReservationFormValues = { ...emptyExtras, ...draft };
@@ -126,28 +118,21 @@
           </select>
         </label>
 
-        <div class="color-field">
-          <span class="color-label">Color</span>
-          <div class="color-swatches" role="radiogroup" aria-label="Reservation color">
-            {#each RESERVATION_COLORS as color}
-              <button
-                type="button"
-                class="swatch"
-                class:selected={form.color === color}
-                style="background: {COLOR_SWATCHES[color]}"
-                aria-label={color}
-                aria-checked={form.color === color}
-                role="radio"
-                on:click={() => { form.color = color; }}
-              >
-                {#if form.color === color}
-                  <span class="check" aria-hidden="true">&#10003;</span>
-                {/if}
-              </button>
-            {/each}
+        <label>
+          <span>Status</span>
+          <div class="status-select-wrapper">
+            <span
+              class="status-indicator"
+              style="background: {STATUS_COLORS[form.status]}"
+              aria-hidden="true"
+            ></span>
+            <select bind:value={form.status} required aria-label="Reservation status">
+              {#each RESERVATION_STATUSES as statusValue}
+                <option value={statusValue}>{STATUS_LABELS[statusValue]}</option>
+              {/each}
+            </select>
           </div>
-          <span class="color-name">{form.color}</span>
-        </div>
+        </label>
 
         <label>
           <span class="notes-label-row">
@@ -293,57 +278,23 @@
     font-size: 0.8rem;
   }
 
-  /* Color swatches */
-  .color-field {
-    display: grid;
-    gap: 0.35rem;
-  }
-
-  .color-label {
-    font-weight: 600;
-    color: #263444;
-    font-size: 0.9rem;
-  }
-
-  .color-swatches {
+  /* Status select */
+  .status-select-wrapper {
     display: flex;
+    align-items: center;
     gap: 0.5rem;
-    flex-wrap: wrap;
   }
 
-  .swatch {
-    width: 40px;
-    height: 40px;
-    min-height: 44px;
-    min-width: 44px;
+  .status-indicator {
+    width: 14px;
+    height: 14px;
+    min-width: 14px;
     border-radius: 50%;
-    border: 2px solid transparent;
-    cursor: pointer;
-    display: grid;
-    place-items: center;
-    padding: 0;
-    transition: border-color 0.15s;
+    flex-shrink: 0;
   }
 
-  .swatch:hover {
-    border-color: #a0b0c4;
-  }
-
-  .swatch.selected {
-    border-color: #1b304a;
-    box-shadow: 0 0 0 2px white, 0 0 0 4px #1b304a;
-  }
-
-  .check {
-    font-size: 1rem;
-    color: #1b304a;
-    font-weight: 700;
-  }
-
-  .color-name {
-    font-size: 0.85rem;
-    color: #455566;
-    text-transform: capitalize;
+  .status-select-wrapper select {
+    flex: 1;
   }
 
   .modal-actions {

--- a/src/lib/domain/models.ts
+++ b/src/lib/domain/models.ts
@@ -1,4 +1,4 @@
-export { RESERVATION_COLORS } from '$lib/types';
+export { RESERVATION_COLORS, RESERVATION_STATUSES } from '$lib/types';
 export type {
   ActionError,
   ActionResult,
@@ -8,5 +8,6 @@ export type {
   Reservation,
   ReservationColor,
   ReservationFormValues,
+  ReservationStatus,
   SiteSettings
 } from '$lib/types';

--- a/src/lib/domain/reservations/index.ts
+++ b/src/lib/domain/reservations/index.ts
@@ -13,6 +13,17 @@ export {
 } from './occupancy';
 
 export {
+	DEFAULT_RESERVATION_STATUS,
+	STATUS_BACKGROUND_COLORS,
+	STATUS_COLORS,
+	STATUS_LABELS,
+	getStatusBackgroundColor,
+	getStatusColor,
+	getStatusLabel,
+	isReservationStatus
+} from './status';
+
+export {
 	checkOverlap,
 	isReservationColor,
 	validateReservationDates,

--- a/src/lib/domain/reservations/status.ts
+++ b/src/lib/domain/reservations/status.ts
@@ -1,0 +1,43 @@
+import {
+	RESERVATION_STATUSES,
+	type ReservationStatus
+} from '$lib/types';
+
+export const DEFAULT_RESERVATION_STATUS: ReservationStatus = 'reserved';
+
+export const STATUS_COLORS: Record<ReservationStatus, string> = {
+	'reserved': '#3b82f6',
+	'checked-in': '#22c55e',
+	'due-out': '#f59e0b',
+	'maintenance': '#6b7280'
+};
+
+export const STATUS_BACKGROUND_COLORS: Record<ReservationStatus, string> = {
+	'reserved': '#dbeafe',
+	'checked-in': '#dcfce7',
+	'due-out': '#fef3c7',
+	'maintenance': '#f3f4f6'
+};
+
+export const STATUS_LABELS: Record<ReservationStatus, string> = {
+	'reserved': 'Reserved',
+	'checked-in': 'Checked In',
+	'due-out': 'Due Out',
+	'maintenance': 'Maintenance'
+};
+
+export function isReservationStatus(value: string): value is ReservationStatus {
+	return (RESERVATION_STATUSES as readonly string[]).includes(value);
+}
+
+export function getStatusColor(status: ReservationStatus): string {
+	return STATUS_COLORS[status];
+}
+
+export function getStatusBackgroundColor(status: ReservationStatus): string {
+	return STATUS_BACKGROUND_COLORS[status];
+}
+
+export function getStatusLabel(status: ReservationStatus): string {
+	return STATUS_LABELS[status];
+}

--- a/src/lib/domain/reservations/validation.ts
+++ b/src/lib/domain/reservations/validation.ts
@@ -6,6 +6,7 @@ import {
 	type ReservationFormValues
 } from '$lib/domain/models';
 import { normalizeName, normalizeReservationNotes, MAX_RESERVATION_NOTES_LENGTH } from './normalization';
+import { isReservationStatus } from './status';
 
 export function isReservationColor(value: string): value is ReservationColor {
 	return (RESERVATION_COLORS as readonly string[]).includes(value);
@@ -78,6 +79,10 @@ export function validateReservationForm(
 
 	if (!isReservationColor(form.color)) {
 		errors.push('Color must be one of: red, green, blue, yellow, pink, orange, purple.');
+	}
+
+	if (!isReservationStatus(form.status)) {
+		errors.push('Status must be one of: reserved, checked-in, due-out, maintenance.');
 	}
 
 	if (errors.length > 0) {

--- a/src/lib/infrastructure/storage/sqlite/app-data-repository.ts
+++ b/src/lib/infrastructure/storage/sqlite/app-data-repository.ts
@@ -1,10 +1,10 @@
 import type { AppDataRepository } from '$lib/application/ports';
-import type { PersistedAppData, Reservation, ReservationColor } from '$lib/domain/models';
-import { buildFirstCellId } from '$lib/domain/reservations';
+import type { PersistedAppData, Reservation, ReservationColor, ReservationStatus } from '$lib/domain/models';
+import { buildFirstCellId, DEFAULT_RESERVATION_STATUS, isReservationStatus } from '$lib/domain/reservations';
 import { DEFAULT_PARKING_LOCATIONS } from '$lib/storage';
 import type { Database } from './types';
 
-const DATA_VERSION = 2;
+const DATA_VERSION = 3;
 
 interface ReservationRow {
 	id: number;
@@ -15,6 +15,7 @@ interface ReservationRow {
 	end_date: string;
 	parking_location: string;
 	color: string;
+	status: string | null;
 }
 
 interface MetadataRow {
@@ -38,6 +39,11 @@ function getDefaultData(): PersistedAppData {
 }
 
 function rowToReservation(row: ReservationRow): Reservation {
+	const status: ReservationStatus =
+		typeof row.status === 'string' && isReservationStatus(row.status)
+			? row.status
+			: DEFAULT_RESERVATION_STATUS;
+
 	return {
 		index: row.id,
 		firstCellId: buildFirstCellId(row.parking_location, row.start_date),
@@ -47,7 +53,8 @@ function rowToReservation(row: ReservationRow): Reservation {
 		startDate: row.start_date,
 		endDate: row.end_date,
 		parkingLocation: row.parking_location,
-		color: row.color as ReservationColor
+		color: row.color as ReservationColor,
+		status
 	};
 }
 
@@ -100,8 +107,8 @@ async function saveToDb(db: Database, data: PersistedAppData): Promise<number> {
 	await db.execute('DELETE FROM reservations');
 	for (const r of data.reservations) {
 		await db.execute(
-			'INSERT INTO reservations (id, name, phone_number, notes, start_date, end_date, parking_location, color) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-			[r.index, r.name, r.phoneNumber, r.notes, r.startDate, r.endDate, r.parkingLocation, r.color]
+			'INSERT INTO reservations (id, name, phone_number, notes, start_date, end_date, parking_location, color, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+			[r.index, r.name, r.phoneNumber, r.notes, r.startDate, r.endDate, r.parkingLocation, r.color, r.status]
 		);
 	}
 

--- a/src/lib/infrastructure/storage/sqlite/migrations/002_add_status.ts
+++ b/src/lib/infrastructure/storage/sqlite/migrations/002_add_status.ts
@@ -1,0 +1,9 @@
+import type { Database } from '../types';
+
+export const version = 2;
+
+export async function up(db: Database): Promise<void> {
+	await db.execute(`
+		ALTER TABLE reservations ADD COLUMN status TEXT NOT NULL DEFAULT 'reserved'
+	`);
+}

--- a/src/lib/infrastructure/storage/sqlite/migrations/index.ts
+++ b/src/lib/infrastructure/storage/sqlite/migrations/index.ts
@@ -1,4 +1,8 @@
 import type { Migration } from '../migrator';
 import * as m001 from './001_initial';
+import * as m002 from './002_add_status';
 
-export const allMigrations: Migration[] = [{ version: m001.version, up: m001.up }];
+export const allMigrations: Migration[] = [
+	{ version: m001.version, up: m001.up },
+	{ version: m002.version, up: m002.up }
+];

--- a/src/lib/infrastructure/storage/sqlite/schema.sql
+++ b/src/lib/infrastructure/storage/sqlite/schema.sql
@@ -1,4 +1,4 @@
--- RV Reservation Demo – SQLite Schema v1
+-- RV Reservation Demo – SQLite Schema v2
 -- Date columns store ISO 8601 local calendar dates (YYYY-MM-DD).
 -- All TEXT columns use UTF-8 encoding (SQLite default).
 
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS reservations (
   end_date          TEXT    NOT NULL,      -- YYYY-MM-DD (exclusive)
   parking_location  TEXT    NOT NULL REFERENCES parking_locations(name),
   color             TEXT    NOT NULL DEFAULT 'blue',
+  status            TEXT    NOT NULL DEFAULT 'reserved',
   CHECK (start_date < end_date),
   CHECK (color IN ('red','green','blue','yellow','pink','orange','purple'))
 );

--- a/src/lib/reservations.ts
+++ b/src/lib/reservations.ts
@@ -1,11 +1,13 @@
 // Re-export from domain layer for backwards compatibility during migration.
 export {
+	DEFAULT_RESERVATION_STATUS,
 	MAX_RESERVATION_NOTES_LENGTH,
 	buildCellId,
 	buildFirstCellId,
 	buildOccupancyMap,
 	checkOverlap as rangesOverlap,
 	isReservationColor,
+	isReservationStatus,
 	normalizeName,
 	normalizePhoneNumber,
 	normalizeReservationNotes,

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,10 +1,10 @@
 import { browser } from '$app/environment';
 import { isIsoDateString } from '$lib/date';
-import { isReservationColor, normalizePhoneNumber, sanitizeReservationNotes } from '$lib/reservations';
-import type { PersistedAppData, Reservation, SiteSettings } from '$lib/types';
+import { DEFAULT_RESERVATION_STATUS, isReservationColor, isReservationStatus, normalizePhoneNumber, sanitizeReservationNotes } from '$lib/reservations';
+import type { PersistedAppData, Reservation, ReservationStatus, SiteSettings } from '$lib/types';
 
 const STORAGE_KEY = 'rv-reservation-demo:v1';
-const DATA_VERSION = 2;
+const DATA_VERSION = 3;
 const SETTINGS_STORAGE_KEY = 'rv-reservation-demo:settings:v1';
 
 export const DEFAULT_SITE_NAME = 'RV Reservation Schedule';
@@ -61,6 +61,12 @@ function sanitizeReservation(value: unknown): Reservation | null {
   if (typeof raw.parkingLocation !== 'string' || !raw.parkingLocation.trim()) return null;
   if (typeof raw.color !== 'string' || !isReservationColor(raw.color)) return null;
 
+  // Migration: default status to 'reserved' for v2 data that lacks it
+  const status: ReservationStatus =
+    typeof raw.status === 'string' && isReservationStatus(raw.status)
+      ? raw.status
+      : DEFAULT_RESERVATION_STATUS;
+
   const phoneNumber =
     typeof raw.phoneNumber === 'string' ? normalizePhoneNumber(raw.phoneNumber) : '';
   const notes = typeof raw.notes === 'string' ? sanitizeReservationNotes(raw.notes) : '';
@@ -74,7 +80,8 @@ function sanitizeReservation(value: unknown): Reservation | null {
     startDate: raw.startDate,
     endDate: raw.endDate,
     parkingLocation: raw.parkingLocation.trim(),
-    color: raw.color
+    color: raw.color,
+    status
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,10 @@ export const RESERVATION_COLORS = [
 
 export type ReservationColor = (typeof RESERVATION_COLORS)[number];
 
+export const RESERVATION_STATUSES = ['reserved', 'checked-in', 'due-out', 'maintenance'] as const;
+
+export type ReservationStatus = (typeof RESERVATION_STATUSES)[number];
+
 export interface Reservation {
   index: number;
   firstCellId: string;
@@ -20,6 +24,7 @@ export interface Reservation {
   endDate: string;
   parkingLocation: string;
   color: ReservationColor;
+  status: ReservationStatus;
 }
 
 export interface PersistedAppData {
@@ -43,6 +48,7 @@ export interface ReservationFormValues {
   endDate: string;
   parkingLocation: string;
   color: ReservationColor;
+  status: ReservationStatus;
 }
 
 export interface SiteSettings {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,9 +11,14 @@
     getTodayIsoLocal
   } from '$lib/date';
   import { buildCellId, buildOccupancyMap } from '$lib/reservations';
+  import {
+    STATUS_BACKGROUND_COLORS,
+    STATUS_COLORS,
+    STATUS_LABELS
+  } from '$lib/domain/reservations/status';
   import { siteSettingsStore } from '$lib/site-settings';
   import { rvReservationStore } from '$lib/state';
-  import type { Reservation, ReservationFormValues } from '$lib/types';
+  import { RESERVATION_STATUSES, type Reservation, type ReservationFormValues, type ReservationStatus } from '$lib/types';
 
   const FIRST_COLUMN_WIDTH = 220;
   const DATE_COLUMN_WIDTH = 128;
@@ -41,7 +46,8 @@
     startDate: todayIso,
     endDate: addDays(todayIso, 1),
     parkingLocation: '',
-    color: 'blue'
+    color: 'blue',
+    status: 'reserved'
   };
 
   // Toast notification state
@@ -116,7 +122,8 @@
         startDate: reservation.startDate,
         endDate: reservation.endDate,
         parkingLocation: reservation.parkingLocation,
-        color: reservation.color
+        color: reservation.color,
+        status: reservation.status
       };
     } else {
       modalMode = 'create';
@@ -127,7 +134,8 @@
         startDate: dateIso,
         endDate: addDays(dateIso, 1),
         parkingLocation,
-        color: 'blue'
+        color: 'blue',
+        status: 'reserved'
       };
     }
 
@@ -193,6 +201,7 @@
 
     const lines = [
       `${reservation.name} (${formatReservationDetail(reservation.startDate)} \u2192 ${formatReservationDetail(reservation.endDate)})`,
+      `Status: ${STATUS_LABELS[reservation.status]}`,
       `Site: ${reservation.parkingLocation}`
     ];
 
@@ -297,6 +306,19 @@
         <button type="button" on:click={() => scrollWeek(1)}>Next Week &#8594;</button>
       </nav>
 
+      <div class="status-legend" aria-label="Status legend">
+        {#each RESERVATION_STATUSES as statusKey}
+          <span class="legend-item">
+            <span
+              class="legend-swatch"
+              style="background: {STATUS_BACKGROUND_COLORS[statusKey]}; border-left: 3px solid {STATUS_COLORS[statusKey]};"
+              aria-hidden="true"
+            ></span>
+            {STATUS_LABELS[statusKey]}
+          </span>
+        {/each}
+      </div>
+
       <div class="sheet-scroll" bind:this={gridScroller}>
         <table class="sheet-table" aria-label="RV reservation schedule">
           <colgroup>
@@ -335,7 +357,8 @@
                   {@const cellId = buildCellId(location, dateIso)}
                   {@const reservation = occupancyMap.get(cellId)}
                   <td
-                    class={`grid-cell ${reservation ? `occupied color-${reservation.color}` : 'empty'} ${dateIso === todayIso ? 'today' : ''}`}
+                    class={`grid-cell ${reservation ? 'occupied' : 'empty'} ${dateIso === todayIso ? 'today' : ''}`}
+                    style={reservation ? `background: ${STATUS_BACKGROUND_COLORS[reservation.status]}; border-left: 3px solid ${STATUS_COLORS[reservation.status]};` : ''}
                     on:click={() => openModalForCell(location, dateIso)}
                     title={getReservationCellTitle(location, dateIso, reservation)}
                   >
@@ -522,6 +545,30 @@
     background: #0757c8;
   }
 
+  /* Status legend */
+  .status-legend {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    color: #334a68;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .legend-swatch {
+    display: inline-block;
+    width: 24px;
+    height: 16px;
+    border-radius: 3px;
+  }
+
   .sheet-scroll {
     overflow: auto;
     max-height: min(70vh, 52rem);
@@ -691,34 +738,6 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
     word-break: break-word;
-  }
-
-  .color-red {
-    background: #ffd9d9;
-  }
-
-  .color-green {
-    background: #ddf7dd;
-  }
-
-  .color-blue {
-    background: #d9ebff;
-  }
-
-  .color-yellow {
-    background: #fff5c6;
-  }
-
-  .color-pink {
-    background: #ffe0ef;
-  }
-
-  .color-orange {
-    background: #ffe5cd;
-  }
-
-  .color-purple {
-    background: #eadfff;
   }
 
   .grid-cell.occupied:hover {

--- a/tests/unit/in-memory-db.ts
+++ b/tests/unit/in-memory-db.ts
@@ -76,6 +76,22 @@ export function createInMemoryDb(): Database & {
 		};
 	}
 
+	function parseAlterTableAddColumn(sql: string): {
+		table: string;
+		column: string;
+		defaultValue: unknown;
+	} | null {
+		const m = sql.match(
+			/ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+(\w+)\s+\w+(?:\s+NOT\s+NULL)?(?:\s+DEFAULT\s+'([^']*)')?/i
+		);
+		if (!m) return null;
+		return {
+			table: m[1],
+			column: m[2],
+			defaultValue: m[3] ?? null
+		};
+	}
+
 	function evaluateWhere(
 		row: Row,
 		whereClause: string,
@@ -188,6 +204,20 @@ export function createInMemoryDb(): Database & {
 					}
 					for (const op of setOps) {
 						row[op.col] = params[op.paramIndex];
+					}
+				}
+				return;
+			}
+
+			// ALTER TABLE ADD COLUMN
+			const alter = parseAlterTableAddColumn(trimmed);
+			if (alter) {
+				const rows = tables.get(alter.table);
+				if (!rows) throw new Error(`Table ${alter.table} does not exist`);
+				// Add the column with the default value to all existing rows
+				for (const row of rows) {
+					if (!(alter.column in row)) {
+						row[alter.column] = alter.defaultValue;
 					}
 				}
 				return;

--- a/tests/unit/migrator.test.ts
+++ b/tests/unit/migrator.test.ts
@@ -8,7 +8,7 @@ describe('runMigrations', () => {
 		const db = createInMemoryDb();
 		const version = await runMigrations(db, allMigrations);
 
-		expect(version).toBe(1);
+		expect(version).toBe(2);
 		expect(db.tables.has('schema_migrations')).toBe(true);
 		expect(db.tables.has('parking_locations')).toBe(true);
 		expect(db.tables.has('reservations')).toBe(true);
@@ -21,8 +21,9 @@ describe('runMigrations', () => {
 		await runMigrations(db, allMigrations);
 
 		const rows = await db.select<{ version: number }>('SELECT * FROM schema_migrations');
-		expect(rows).toHaveLength(1);
+		expect(rows).toHaveLength(2);
 		expect(rows[0].version).toBe(1);
+		expect(rows[1].version).toBe(2);
 	});
 
 	it('is idempotent — re-running does not re-apply migrations', async () => {
@@ -30,9 +31,9 @@ describe('runMigrations', () => {
 		await runMigrations(db, allMigrations);
 		const version2 = await runMigrations(db, allMigrations);
 
-		expect(version2).toBe(1);
+		expect(version2).toBe(2);
 		const rows = await db.select<{ version: number }>('SELECT * FROM schema_migrations');
-		expect(rows).toHaveLength(1);
+		expect(rows).toHaveLength(2);
 	});
 
 	it('applies only new migrations when database is partially migrated', async () => {
@@ -40,8 +41,8 @@ describe('runMigrations', () => {
 		const firstMigration: Migration[] = [allMigrations[0]];
 		await runMigrations(db, firstMigration);
 
-		const fakeMigration2: Migration = {
-			version: 2,
+		const fakeMigration3: Migration = {
+			version: 3,
 			async up(d) {
 				await d.execute(
 					'CREATE TABLE IF NOT EXISTS test_table (id INTEGER PRIMARY KEY)'
@@ -49,8 +50,8 @@ describe('runMigrations', () => {
 			}
 		};
 
-		const version = await runMigrations(db, [...firstMigration, fakeMigration2]);
-		expect(version).toBe(2);
+		const version = await runMigrations(db, [...firstMigration, fakeMigration3]);
+		expect(version).toBe(3);
 		expect(db.tables.has('test_table')).toBe(true);
 
 		const rows = await db.select<{ version: number }>('SELECT * FROM schema_migrations');

--- a/tests/unit/sqlite-repositories.test.ts
+++ b/tests/unit/sqlite-repositories.test.ts
@@ -17,6 +17,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		endDate: '2025-03-05',
 		parkingLocation: 'A-01',
 		color: 'blue',
+		status: 'reserved',
 		...overrides
 	};
 }
@@ -34,7 +35,7 @@ describe('SQLite AppDataRepository', () => {
 		await repo.init();
 		const data = repo.load();
 
-		expect(data.version).toBe(2);
+		expect(data.version).toBe(3);
 		expect(data.reservations).toEqual([]);
 		expect(data.parkingLocations).toHaveLength(10);
 		expect(data.parkingLocations[0]).toBe('A-01');
@@ -46,7 +47,7 @@ describe('SQLite AppDataRepository', () => {
 		await repo.init();
 
 		const data: PersistedAppData = {
-			version: 2,
+			version: 3,
 			reservations: [
 				makeReservation({ index: 1 }),
 				makeReservation({ index: 2, name: 'Another Guest', startDate: '2025-04-01', endDate: '2025-04-03', firstCellId: 'A-01::2025-04-01' })
@@ -78,7 +79,7 @@ describe('SQLite AppDataRepository', () => {
 		await repo.init();
 
 		const data: PersistedAppData = {
-			version: 2,
+			version: 3,
 			reservations: [],
 			parkingLocations: ['Z-99', 'A-01', 'M-50'],
 			nextReservationIndex: 1,
@@ -98,7 +99,7 @@ describe('SQLite AppDataRepository', () => {
 		await repo.init();
 
 		repo.save({
-			version: 2,
+			version: 3,
 			reservations: [makeReservation()],
 			parkingLocations: ['A-01'],
 			nextReservationIndex: 5,
@@ -122,7 +123,7 @@ describe('SQLite AppDataRepository', () => {
 		const repo = createSqliteAppDataRepository(db);
 		const defaults = repo.getDefaultData();
 
-		expect(defaults.version).toBe(2);
+		expect(defaults.version).toBe(3);
 		expect(defaults.reservations).toEqual([]);
 		expect(defaults.parkingLocations).toHaveLength(10);
 		expect(defaults.nextReservationIndex).toBe(1);

--- a/tests/unit/status-migration.test.ts
+++ b/tests/unit/status-migration.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import {
+	DEFAULT_RESERVATION_STATUS,
+	STATUS_COLORS,
+	STATUS_BACKGROUND_COLORS,
+	STATUS_LABELS,
+	isReservationStatus,
+	getStatusColor,
+	getStatusBackgroundColor,
+	getStatusLabel
+} from '$lib/domain/reservations/status';
+import { RESERVATION_STATUSES } from '$lib/types';
+
+describe('ReservationStatus type', () => {
+	it('defines exactly four statuses', () => {
+		expect(RESERVATION_STATUSES).toEqual(['reserved', 'checked-in', 'due-out', 'maintenance']);
+	});
+
+	it('default status is reserved', () => {
+		expect(DEFAULT_RESERVATION_STATUS).toBe('reserved');
+	});
+});
+
+describe('isReservationStatus', () => {
+	it('returns true for all valid statuses', () => {
+		expect(isReservationStatus('reserved')).toBe(true);
+		expect(isReservationStatus('checked-in')).toBe(true);
+		expect(isReservationStatus('due-out')).toBe(true);
+		expect(isReservationStatus('maintenance')).toBe(true);
+	});
+
+	it('returns false for invalid statuses', () => {
+		expect(isReservationStatus('')).toBe(false);
+		expect(isReservationStatus('active')).toBe(false);
+		expect(isReservationStatus('cancelled')).toBe(false);
+		expect(isReservationStatus('blue')).toBe(false);
+	});
+});
+
+describe('STATUS_COLORS', () => {
+	it('maps reserved to blue (#3b82f6)', () => {
+		expect(STATUS_COLORS['reserved']).toBe('#3b82f6');
+	});
+
+	it('maps checked-in to green (#22c55e)', () => {
+		expect(STATUS_COLORS['checked-in']).toBe('#22c55e');
+	});
+
+	it('maps due-out to amber (#f59e0b)', () => {
+		expect(STATUS_COLORS['due-out']).toBe('#f59e0b');
+	});
+
+	it('maps maintenance to gray (#6b7280)', () => {
+		expect(STATUS_COLORS['maintenance']).toBe('#6b7280');
+	});
+});
+
+describe('STATUS_BACKGROUND_COLORS', () => {
+	it('has a background color for every status', () => {
+		for (const status of RESERVATION_STATUSES) {
+			expect(STATUS_BACKGROUND_COLORS[status]).toBeDefined();
+			expect(STATUS_BACKGROUND_COLORS[status]).toMatch(/^#[0-9a-f]{6}$/);
+		}
+	});
+});
+
+describe('STATUS_LABELS', () => {
+	it('provides human-readable labels', () => {
+		expect(STATUS_LABELS['reserved']).toBe('Reserved');
+		expect(STATUS_LABELS['checked-in']).toBe('Checked In');
+		expect(STATUS_LABELS['due-out']).toBe('Due Out');
+		expect(STATUS_LABELS['maintenance']).toBe('Maintenance');
+	});
+});
+
+describe('getStatusColor', () => {
+	it('returns the correct color for each status', () => {
+		expect(getStatusColor('reserved')).toBe('#3b82f6');
+		expect(getStatusColor('checked-in')).toBe('#22c55e');
+		expect(getStatusColor('due-out')).toBe('#f59e0b');
+		expect(getStatusColor('maintenance')).toBe('#6b7280');
+	});
+});
+
+describe('getStatusBackgroundColor', () => {
+	it('returns a background color for each status', () => {
+		for (const status of RESERVATION_STATUSES) {
+			expect(getStatusBackgroundColor(status)).toBe(STATUS_BACKGROUND_COLORS[status]);
+		}
+	});
+});
+
+describe('getStatusLabel', () => {
+	it('returns the label for each status', () => {
+		for (const status of RESERVATION_STATUSES) {
+			expect(getStatusLabel(status)).toBe(STATUS_LABELS[status]);
+		}
+	});
+});
+
+describe('storage migration v2 → v3', () => {
+	it('existing reservations without status get default "reserved"', () => {
+		// Simulate a v2 reservation (no status field)
+		const v2Reservation = {
+			index: 1,
+			firstCellId: 'A-01::2026-03-01',
+			name: 'John Doe',
+			phoneNumber: '555-1234',
+			notes: '',
+			startDate: '2026-03-01',
+			endDate: '2026-03-05',
+			parkingLocation: 'A-01',
+			color: 'blue'
+		};
+
+		// When migrated, status should default to 'reserved'
+		const status = typeof (v2Reservation as Record<string, unknown>).status === 'string' &&
+			isReservationStatus((v2Reservation as Record<string, unknown>).status as string)
+			? (v2Reservation as Record<string, unknown>).status
+			: DEFAULT_RESERVATION_STATUS;
+
+		expect(status).toBe('reserved');
+	});
+
+	it('preserves existing status if it is valid', () => {
+		const v3Reservation = {
+			index: 1,
+			firstCellId: 'A-01::2026-03-01',
+			name: 'Jane Smith',
+			phoneNumber: '',
+			notes: '',
+			startDate: '2026-03-01',
+			endDate: '2026-03-05',
+			parkingLocation: 'A-01',
+			color: 'green',
+			status: 'checked-in'
+		};
+
+		const status = typeof v3Reservation.status === 'string' &&
+			isReservationStatus(v3Reservation.status)
+			? v3Reservation.status
+			: DEFAULT_RESERVATION_STATUS;
+
+		expect(status).toBe('checked-in');
+	});
+
+	it('falls back to default for invalid status values', () => {
+		const badReservation = {
+			index: 1,
+			status: 'invalid-status'
+		};
+
+		const status = typeof badReservation.status === 'string' &&
+			isReservationStatus(badReservation.status)
+			? badReservation.status
+			: DEFAULT_RESERVATION_STATUS;
+
+		expect(status).toBe('reserved');
+	});
+});


### PR DESCRIPTION
## Summary
- Add `ReservationStatus` type (`reserved`, `checked-in`, `due-out`, `maintenance`) to the domain layer with status-to-color mapping, labels, and background colors
- Replace the decorative color picker in `ReservationModal` with a semantic status dropdown showing a colored indicator
- Render status-based colors on the working sheet grid cells (background + left border) and add a status legend below the navigation bar
- Migrate localStorage data version from v2 to v3 — existing reservations default to `reserved` status
- Add SQLite migration `002_add_status` adding the `status` column with default `'reserved'`
- Add unit tests for status domain logic and migration behavior

## Test plan
- [x] `npm run test:unit` — 40 tests pass (including 16 new status/migration tests)
- [x] `npm run check` — 0 errors
- [x] `npm run build` — production build succeeds
- [ ] Manual: verify status dropdown appears in reservation modal
- [ ] Manual: verify grid cells render with status-based colors
- [ ] Manual: verify status legend displays below grid navigation
- [ ] Manual: verify existing reservations load with "Reserved" status after migration