### PR TITLE
feat: standardize date formatting across UI

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -65,6 +65,51 @@ export function formatDisplayDate(isoDate: string): string {
   return `${String(day).padStart(2, '0')}/${String(month).padStart(2, '0')}/${year}`;
 }
 
+const SHORT_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+const SHORT_MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+] as const;
+
+/**
+ * Compact format for grid/schedule column headers.
+ * Example: "Sat, Mar 7"
+ */
+export function formatScheduleHeader(isoDate: string): string {
+  const parts = parseIsoParts(isoDate);
+  if (!parts) return isoDate;
+  const [year, month, day] = parts;
+  const utcMs = Date.UTC(year, month - 1, day);
+  const dow = new Date(utcMs).getUTCDay();
+  return `${SHORT_DAYS[dow]}, ${SHORT_MONTHS[month - 1]} ${day}`;
+}
+
+/**
+ * Explicit format for reservation detail displays.
+ * Example: "Mar 7, 2026"
+ */
+export function formatReservationDetail(isoDate: string): string {
+  const parts = parseIsoParts(isoDate);
+  if (!parts) return isoDate;
+  const [year, month, day] = parts;
+  return `${SHORT_MONTHS[month - 1]} ${day}, ${year}`;
+}
+
+/**
+ * Locale-aware readable timestamp for autosave and audit displays.
+ * Example: "Mar 7, 2026, 2:30 PM"
+ */
+export function formatTimestamp(date: Date | number): string {
+  const d = typeof date === 'number' ? new Date(date) : date;
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  }).format(d);
+}
+
 export function getTodayIsoLocal(now: Date = new Date()): string {
   const year = now.getFullYear();
   const month = String(now.getMonth() + 1).padStart(2, '0');

--- a/src/lib/domain/reservations/validation.ts
+++ b/src/lib/domain/reservations/validation.ts
@@ -1,4 +1,4 @@
-import { compareIsoDates, isIsoDateString } from '$lib/date';
+import { compareIsoDates, formatReservationDetail, isIsoDateString } from '$lib/date';
 import {
 	RESERVATION_COLORS,
 	type Reservation,
@@ -95,7 +95,7 @@ export function validateReservationForm(
 
 		if (checkOverlap(form.startDate, form.endDate, reservation.startDate, reservation.endDate)) {
 			errors.push(
-				`Overlap with reservation #${reservation.index} (${reservation.name}) at ${reservation.parkingLocation} from ${reservation.startDate} to ${reservation.endDate}.`
+				`Overlap with reservation #${reservation.index} (${reservation.name}) at ${reservation.parkingLocation} from ${formatReservationDetail(reservation.startDate)} to ${formatReservationDetail(reservation.endDate)}.`
 			);
 			break;
 		}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,9 @@
   import {
     addDays,
     diffDays,
-    formatDisplayDate,
-    formatLocalTimestamp,
+    formatReservationDetail,
+    formatScheduleHeader,
+    formatTimestamp,
     getTodayIsoLocal
   } from '$lib/date';
   import { buildCellId, buildOccupancyMap } from '$lib/reservations';
@@ -72,16 +73,16 @@
     const ageMs = Math.max(0, nowTimestamp - lastSavedAt);
     const ageMinutes = Math.floor(ageMs / 60000);
     if (ageMinutes <= 0) {
-      return `Saved just now (${formatLocalTimestamp(lastSavedAt)})`;
+      return `Saved just now (${formatTimestamp(lastSavedAt)})`;
     }
     if (ageMinutes === 1) {
-      return `Saved 1 minute ago (${formatLocalTimestamp(lastSavedAt)})`;
+      return `Saved 1 minute ago (${formatTimestamp(lastSavedAt)})`;
     }
     if (ageMinutes < 60) {
-      return `Saved ${ageMinutes} minutes ago (${formatLocalTimestamp(lastSavedAt)})`;
+      return `Saved ${ageMinutes} minutes ago (${formatTimestamp(lastSavedAt)})`;
     }
     const ageHours = Math.floor(ageMinutes / 60);
-    return `Saved ${ageHours}h ago (${formatLocalTimestamp(lastSavedAt)})`;
+    return `Saved ${ageHours}h ago (${formatTimestamp(lastSavedAt)})`;
   }
 
   async function alignToToday(): Promise<void> {
@@ -187,11 +188,11 @@
 
   function getReservationCellTitle(location: string, dateIso: string, reservation?: Reservation): string {
     if (!reservation) {
-      return `Click to add reservation at ${location} on ${dateIso}`;
+      return `Click to add reservation at ${location} on ${formatScheduleHeader(dateIso)}`;
     }
 
     const lines = [
-      `${reservation.name} (${reservation.startDate} \u2192 ${reservation.endDate})`,
+      `${reservation.name} (${formatReservationDetail(reservation.startDate)} \u2192 ${formatReservationDetail(reservation.endDate)})`,
       `Location: ${reservation.parkingLocation}`
     ];
 
@@ -310,7 +311,7 @@
               <th class="sticky-row1 sticky-col top-left-cell location-header" scope="col">
                 <div class="top-left-content">
                   <span class="label">Current Date</span>
-                  <strong>{formatDisplayDate(todayIso)}</strong>
+                  <strong>{formatReservationDetail(todayIso)}</strong>
                 </div>
               </th>
               {#each dateColumns as dateIso}
@@ -320,7 +321,7 @@
                   scope="col"
                   data-date={dateIso}
                 >
-                  {formatDisplayDate(dateIso)}
+                  {formatScheduleHeader(dateIso)}
                 </th>
               {/each}
             </tr>

--- a/tests/unit/date-formatting.test.ts
+++ b/tests/unit/date-formatting.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import {
+	formatScheduleHeader,
+	formatReservationDetail,
+	formatTimestamp,
+	formatDisplayDate,
+	formatLocalTimestamp
+} from '$lib/date';
+
+describe('formatScheduleHeader', () => {
+	it('formats a Saturday in March', () => {
+		expect(formatScheduleHeader('2026-03-07')).toBe('Sat, Mar 7');
+	});
+
+	it('formats a Monday in January', () => {
+		expect(formatScheduleHeader('2026-01-05')).toBe('Mon, Jan 5');
+	});
+
+	it('formats New Years Day 2026 (Thursday)', () => {
+		expect(formatScheduleHeader('2026-01-01')).toBe('Thu, Jan 1');
+	});
+
+	it('formats a date in December', () => {
+		expect(formatScheduleHeader('2025-12-25')).toBe('Thu, Dec 25');
+	});
+
+	it('formats a date in February', () => {
+		expect(formatScheduleHeader('2026-02-14')).toBe('Sat, Feb 14');
+	});
+
+	it('formats last day of year', () => {
+		expect(formatScheduleHeader('2025-12-31')).toBe('Wed, Dec 31');
+	});
+
+	it('returns raw string for invalid input', () => {
+		expect(formatScheduleHeader('not-a-date')).toBe('not-a-date');
+	});
+
+	it('handles single-digit days without zero-padding', () => {
+		// Day 1 should show as "1", not "01"
+		expect(formatScheduleHeader('2026-03-01')).toBe('Sun, Mar 1');
+	});
+
+	it('handles double-digit days', () => {
+		expect(formatScheduleHeader('2026-03-15')).toBe('Sun, Mar 15');
+	});
+});
+
+describe('formatReservationDetail', () => {
+	it('formats a date with year', () => {
+		expect(formatReservationDetail('2026-03-07')).toBe('Mar 7, 2026');
+	});
+
+	it('formats January 1st', () => {
+		expect(formatReservationDetail('2026-01-01')).toBe('Jan 1, 2026');
+	});
+
+	it('formats December 31st', () => {
+		expect(formatReservationDetail('2025-12-31')).toBe('Dec 31, 2025');
+	});
+
+	it('formats a leap day', () => {
+		expect(formatReservationDetail('2024-02-29')).toBe('Feb 29, 2024');
+	});
+
+	it('returns raw string for invalid input', () => {
+		expect(formatReservationDetail('bad')).toBe('bad');
+	});
+
+	it('handles all twelve months', () => {
+		const months = [
+			['2026-01-15', 'Jan 15, 2026'],
+			['2026-02-15', 'Feb 15, 2026'],
+			['2026-03-15', 'Mar 15, 2026'],
+			['2026-04-15', 'Apr 15, 2026'],
+			['2026-05-15', 'May 15, 2026'],
+			['2026-06-15', 'Jun 15, 2026'],
+			['2026-07-15', 'Jul 15, 2026'],
+			['2026-08-15', 'Aug 15, 2026'],
+			['2026-09-15', 'Sep 15, 2026'],
+			['2026-10-15', 'Oct 15, 2026'],
+			['2026-11-15', 'Nov 15, 2026'],
+			['2026-12-15', 'Dec 15, 2026']
+		];
+		for (const [input, expected] of months) {
+			expect(formatReservationDetail(input)).toBe(expected);
+		}
+	});
+});
+
+describe('formatTimestamp', () => {
+	it('returns a non-empty string for a numeric timestamp', () => {
+		const result = formatTimestamp(1709827200000);
+		expect(result).toBeTruthy();
+		expect(typeof result).toBe('string');
+	});
+
+	it('returns a non-empty string for a Date object', () => {
+		const result = formatTimestamp(new Date(2026, 2, 7, 14, 30));
+		expect(result).toBeTruthy();
+		expect(typeof result).toBe('string');
+	});
+
+	it('includes the year in the output', () => {
+		const result = formatTimestamp(new Date(2026, 2, 7, 14, 30));
+		expect(result).toContain('2026');
+	});
+
+	it('includes the month abbreviation in the output', () => {
+		const result = formatTimestamp(new Date(2026, 2, 7, 14, 30));
+		expect(result).toContain('Mar');
+	});
+});
+
+describe('formatDisplayDate (legacy)', () => {
+	it('still works with DD/MM/YYYY format', () => {
+		expect(formatDisplayDate('2026-03-07')).toBe('07/03/2026');
+	});
+
+	it('returns raw string for invalid input', () => {
+		expect(formatDisplayDate('invalid')).toBe('invalid');
+	});
+});
+
+describe('formatLocalTimestamp (legacy)', () => {
+	it('returns a non-empty string', () => {
+		const result = formatLocalTimestamp(1709827200000);
+		expect(result).toBeTruthy();
+		expect(typeof result).toBe('string');
+	});
+});


### PR DESCRIPTION
## Summary
- Add centralized date formatting functions (formatScheduleHeader, formatReservationDetail, formatTimestamp)
- Replace all raw/hard-coded date displays with consistent formatting
- Grid headers show "Sat, Mar 7", reservation details show "Mar 7, 2026"

## Test plan
- [ ] Unit tests for date formatting functions (22 new tests)
- [ ] Playwright e2e tests pass with updated date assertions
- [ ] `npm run check` and `npm run build` pass