### PR TITLE
feat: add New Reservation button for discoverability

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -118,6 +118,23 @@
     gridScroller?.scrollBy({ left: DATE_COLUMN_WIDTH * 7 * direction, behavior: 'smooth' });
   }
 
+  function openNewReservationModal(): void {
+    const firstLocation = $rvReservationStore.parkingLocations[0] ?? '';
+    modalMode = 'create';
+    modalDraft = {
+      name: '',
+      phoneNumber: '',
+      notes: '',
+      startDate: todayIso,
+      endDate: addDays(todayIso, 1),
+      parkingLocation: firstLocation,
+      color: 'blue',
+      status: 'reserved'
+    };
+    modalErrors = [];
+    modalOpen = true;
+  }
+
   function openModalForCell(parkingLocation: string, dateIso: string, event?: MouseEvent): void {
     modalTriggerElement = (event?.currentTarget as HTMLElement) ?? null;
     const reservation = occupancyMap.get(buildCellId(parkingLocation, dateIso));
@@ -289,6 +306,7 @@
     </nav>
 
     <div class="toolbar-right">
+      <button type="button" class="new-reservation-btn" data-testid="new-reservation-btn" on:click={openNewReservationModal}>+ New Reservation</button>
       <span class="badge">{ $rvReservationStore.reservations.length } res</span>
       <span class="badge">{ $rvReservationStore.parkingLocations.length } sites</span>
       <span class="badge save-badge" aria-live="polite">{autosaveStatus}</span>
@@ -334,6 +352,12 @@
           </span>
         {/each}
       </div>
+
+      {#if $rvReservationStore.reservations.length === 0 && $rvReservationStore.parkingLocations.length > 0}
+        <div class="empty-state" data-testid="empty-state">
+          <p>No reservations yet. Click <button type="button" class="inline-action" on:click={openNewReservationModal}>+ New Reservation</button> above or click any cell in the calendar to get started.</p>
+        </div>
+      {/if}
 
       <div class="sheet-scroll" bind:this={gridScroller}>
         <table class="sheet-table" aria-label="RV reservation schedule">
@@ -593,6 +617,38 @@
     margin-left: 0.25rem;
   }
 
+  /* Empty state prompt */
+  .empty-state {
+    background: #f0f6ff;
+    border: 1px dashed #b0c4de;
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    text-align: center;
+    color: #3d5a78;
+    font-size: 0.95rem;
+  }
+
+  .empty-state p {
+    margin: 0;
+    line-height: 1.6;
+  }
+
+  .inline-action {
+    background: none;
+    border: none;
+    color: #16a34a;
+    font-weight: 700;
+    cursor: pointer;
+    padding: 0;
+    font-size: inherit;
+    text-decoration: underline;
+    min-height: auto;
+  }
+
+  .inline-action:hover {
+    color: #15803d;
+  }
+
   .sheet-scroll {
     overflow: auto;
     max-height: min(82vh, 60rem);
@@ -740,18 +796,19 @@
   }
 
   .grid-cell.empty .empty-hint {
-    display: none;
-    color: #a0b0c4;
+    display: grid;
+    color: #d0d8e4;
     font-size: 1.1rem;
     font-weight: 300;
     position: absolute;
     inset: 0;
     place-content: center;
     place-items: center;
+    transition: color 0.15s;
   }
 
   .grid-cell.empty:hover .empty-hint {
-    display: grid;
+    color: #8899b0;
   }
 
   .grid-cell.occupied {
@@ -809,6 +866,10 @@
 
     .save-badge {
       display: none;
+    }
+
+    .grid-nav {
+      flex-wrap: wrap;
     }
   }
 </style>

--- a/tests/e2e/reservations.spec.ts
+++ b/tests/e2e/reservations.spec.ts
@@ -203,6 +203,72 @@ test.describe('Modal accessibility and UX', () => {
 	});
 });
 
+test.describe('New Reservation button', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('button is visible and opens modal in create mode', async ({ page }) => {
+		const btn = page.getByTestId('new-reservation-btn');
+		await expect(btn).toBeVisible();
+		await expect(btn).toHaveText('+ New Reservation');
+
+		await btn.click();
+		await expect(modal(page)).toBeVisible();
+		await expect(modal(page).locator('#reservation-modal-title')).toHaveText('New Reservation');
+	});
+
+	test('create a reservation via New Reservation button', async ({ page }) => {
+		const today = getTodayIso();
+		const endDate = offsetDate(3);
+
+		await page.getByTestId('new-reservation-btn').click();
+		await expect(modal(page)).toBeVisible();
+
+		await modal(page).locator('input[placeholder="Guest name"]').fill('Button Guest');
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+
+		// Verify reservation appears in the grid
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.scrollIntoViewIfNeeded();
+		await expect(occupied.locator('.reservation-label')).toHaveText('Button Guest');
+	});
+
+	test('empty state prompt is shown when no reservations exist', async ({ page }) => {
+		const emptyState = page.getByTestId('empty-state');
+		await expect(emptyState).toBeVisible();
+		await expect(emptyState).toContainText('No reservations yet');
+
+		// Clicking inline action in empty state also opens modal
+		await emptyState.locator('button.inline-action').click();
+		await expect(modal(page)).toBeVisible();
+		await expect(modal(page).locator('#reservation-modal-title')).toHaveText('New Reservation');
+		await modal(page).locator('button:has-text("Cancel")').click();
+		await expect(modal(page)).not.toBeVisible();
+	});
+
+	test('empty state disappears after creating a reservation', async ({ page }) => {
+		const emptyState = page.getByTestId('empty-state');
+		await expect(emptyState).toBeVisible();
+
+		const today = getTodayIso();
+		const endDate = offsetDate(2);
+
+		await page.getByTestId('new-reservation-btn').click();
+		await modal(page).locator('input[placeholder="Guest name"]').fill('First Res');
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+
+		await expect(emptyState).not.toBeVisible();
+	});
+});
+
 test.describe('TODAY alignment', () => {
 	test('today column is visible on initial load', async ({ page }) => {
 		await resetApp(page);


### PR DESCRIPTION
## Summary
- Add prominent "New Reservation" button in header area
- Improve empty cell visual affordance for touch/keyboard users
- Add empty-state prompt when no reservations exist
- All create paths route through the same ReservationModal

## Test plan
- [ ] New Reservation button opens modal in create mode
- [ ] Cell-click creation still works
- [ ] Empty-state prompt visible when no reservations
- [ ] Playwright e2e tests pass
- [ ] `npm run check` and `npm run build` pass

> Note: Button placement may need adjustment after issue 004 (toolbar) merges.