### PR TITLE
feat: add search and quick reservation lookup

### DIFF
--- a/src/lib/domain/reservations/index.ts
+++ b/src/lib/domain/reservations/index.ts
@@ -32,3 +32,6 @@ export {
 	validateReservationDates,
 	validateReservationForm
 } from './validation';
+
+export { filterReservations } from './search';
+export type { SearchResult } from './search';

--- a/src/lib/domain/reservations/search.ts
+++ b/src/lib/domain/reservations/search.ts
@@ -1,0 +1,61 @@
+import type { Reservation } from '$lib/types';
+
+export interface SearchResult {
+	reservation: Reservation;
+	/** Lower score = better match. Exact matches get 0, startsWith gets 1, contains gets 2. */
+	score: number;
+}
+
+/**
+ * Filter reservations by a search query, matching against guest name and parking location.
+ * Returns results sorted by relevance: exact match first, then startsWith, then contains.
+ * Within the same relevance tier, results are sorted alphabetically by guest name.
+ *
+ * This is a pure domain function with no side effects.
+ */
+export function filterReservations(
+	reservations: readonly Reservation[],
+	query: string
+): SearchResult[] {
+	const trimmed = query.trim();
+	if (trimmed === '') return [];
+
+	const lowerQuery = trimmed.toLowerCase();
+	const results: SearchResult[] = [];
+
+	for (const reservation of reservations) {
+		const lowerName = reservation.name.toLowerCase();
+		const lowerLocation = reservation.parkingLocation.toLowerCase();
+
+		let bestScore = Infinity;
+
+		// Check guest name
+		if (lowerName === lowerQuery) {
+			bestScore = Math.min(bestScore, 0);
+		} else if (lowerName.startsWith(lowerQuery)) {
+			bestScore = Math.min(bestScore, 1);
+		} else if (lowerName.includes(lowerQuery)) {
+			bestScore = Math.min(bestScore, 2);
+		}
+
+		// Check parking location
+		if (lowerLocation === lowerQuery) {
+			bestScore = Math.min(bestScore, 0);
+		} else if (lowerLocation.startsWith(lowerQuery)) {
+			bestScore = Math.min(bestScore, 1);
+		} else if (lowerLocation.includes(lowerQuery)) {
+			bestScore = Math.min(bestScore, 2);
+		}
+
+		if (bestScore !== Infinity) {
+			results.push({ reservation, score: bestScore });
+		}
+	}
+
+	results.sort((a, b) => {
+		if (a.score !== b.score) return a.score - b.score;
+		return a.reservation.name.localeCompare(b.reservation.name);
+	});
+
+	return results;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
     getTodayIsoLocal
   } from '$lib/date';
   import { computeDailySummary } from '$lib/domain/reservations/daily-summary';
+  import { filterReservations } from '$lib/domain/reservations/search';
   import { buildCellId, buildOccupancyMap } from '$lib/reservations';
   import {
     STATUS_BACKGROUND_COLORS,
@@ -51,6 +52,68 @@
     color: 'blue',
     status: 'reserved'
   };
+
+  // Search state
+  let searchQuery = '';
+  let searchOpen = false;
+  let searchInputEl: HTMLInputElement | null = null;
+  let searchContainerEl: HTMLDivElement | null = null;
+  let selectedSearchIndex = -1;
+
+  $: searchResults = filterReservations($rvReservationStore.reservations, searchQuery);
+  $: if (searchQuery.trim() !== '') {
+    searchOpen = true;
+    selectedSearchIndex = -1;
+  } else {
+    searchOpen = false;
+  }
+
+  function handleSearchKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      searchOpen = false;
+      searchQuery = '';
+      searchInputEl?.blur();
+      return;
+    }
+    if (!searchOpen || searchResults.length === 0) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      selectedSearchIndex = Math.min(selectedSearchIndex + 1, searchResults.length - 1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      selectedSearchIndex = Math.max(selectedSearchIndex - 1, 0);
+    } else if (event.key === 'Enter' && selectedSearchIndex >= 0) {
+      event.preventDefault();
+      openReservationFromSearch(searchResults[selectedSearchIndex].reservation);
+    }
+  }
+
+  function openReservationFromSearch(reservation: Reservation): void {
+    searchOpen = false;
+    searchQuery = '';
+
+    modalMode = 'edit';
+    modalDraft = {
+      index: reservation.index,
+      name: reservation.name,
+      phoneNumber: reservation.phoneNumber,
+      notes: reservation.notes,
+      startDate: reservation.startDate,
+      endDate: reservation.endDate,
+      parkingLocation: reservation.parkingLocation,
+      color: reservation.color,
+      status: reservation.status
+    };
+    modalErrors = [];
+    modalOpen = true;
+  }
+
+  function handleSearchClickOutside(event: MouseEvent): void {
+    if (searchContainerEl && !searchContainerEl.contains(event.target as Node)) {
+      searchOpen = false;
+    }
+  }
 
   // Toast notification state
   let toastMessage = '';
@@ -276,12 +339,14 @@
     };
 
     window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('click', handleSearchClickOutside);
 
     return () => {
       retryTimers.forEach((t) => window.clearTimeout(t));
       window.clearInterval(displayTicker);
       window.clearInterval(autosaveTicker);
       window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('click', handleSearchClickOutside);
       if (toastTimer) clearTimeout(toastTimer);
     };
   });
@@ -306,6 +371,51 @@
     </nav>
 
     <div class="toolbar-right">
+      <div class="search-container" bind:this={searchContainerEl}>
+        <div class="search-input-wrap">
+          <svg class="search-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" width="16" height="16">
+            <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z" clip-rule="evenodd" />
+          </svg>
+          <input
+            type="search"
+            class="search-input"
+            placeholder="Search guests..."
+            bind:value={searchQuery}
+            bind:this={searchInputEl}
+            on:keydown={handleSearchKeydown}
+            aria-label="Search reservations"
+            aria-expanded={searchOpen && searchResults.length > 0}
+            aria-controls="search-results-dropdown"
+            role="combobox"
+            aria-autocomplete="list"
+          />
+        </div>
+        {#if searchOpen && searchResults.length > 0}
+          <ul class="search-dropdown" id="search-results-dropdown" role="listbox">
+            {#each searchResults.slice(0, 15) as result, i}
+              <li
+                class="search-result"
+                class:selected={i === selectedSearchIndex}
+                role="option"
+                aria-selected={i === selectedSearchIndex}
+                on:click={() => openReservationFromSearch(result.reservation)}
+                on:keydown={(e) => { if (e.key === 'Enter') openReservationFromSearch(result.reservation); }}
+                on:mouseenter={() => { selectedSearchIndex = i; }}
+              >
+                <span class="search-result-name">{result.reservation.name}</span>
+                <span class="search-result-meta">
+                  <span class="search-result-location">{result.reservation.parkingLocation}</span>
+                  <span class="search-result-dates">{formatReservationDetail(result.reservation.startDate)} - {formatReservationDetail(result.reservation.endDate)}</span>
+                </span>
+              </li>
+            {/each}
+          </ul>
+        {:else if searchOpen && searchQuery.trim() !== ''}
+          <div class="search-dropdown search-no-results" id="search-results-dropdown">
+            No results found
+          </div>
+        {/if}
+      </div>
       <button type="button" class="new-reservation-btn" data-testid="new-reservation-btn" on:click={openNewReservationModal}>+ New Reservation</button>
       <span class="badge">{ $rvReservationStore.reservations.length } res</span>
       <span class="badge">{ $rvReservationStore.parkingLocations.length } sites</span>
@@ -859,6 +969,101 @@
     filter: brightness(0.97);
   }
 
+  /* Search */
+  .search-container {
+    position: relative;
+    align-self: center;
+    min-width: 14rem;
+  }
+
+  .search-input-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .search-icon {
+    position: absolute;
+    left: 0.65rem;
+    color: #7a8da4;
+    pointer-events: none;
+  }
+
+  .search-input {
+    width: 100%;
+    border-radius: 10px;
+    border: 1px solid #c3cddd;
+    background: #f4f7fc;
+    padding: 0.6rem 0.75rem 0.6rem 2rem;
+    font-size: 0.9rem;
+    color: #1c2e45;
+    min-height: 44px;
+  }
+
+  .search-input::placeholder {
+    color: #8a9bb2;
+  }
+
+  .search-input:focus {
+    background: white;
+    border-color: #0a63e0;
+  }
+
+  .search-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: white;
+    border: 1px solid #d6deea;
+    border-radius: 12px;
+    box-shadow: 0 12px 36px rgba(10, 24, 47, 0.14);
+    z-index: 50;
+    max-height: 24rem;
+    overflow-y: auto;
+    list-style: none;
+    margin: 0;
+    padding: 0.35rem;
+  }
+
+  .search-no-results {
+    padding: 0.85rem 0.75rem;
+    color: #6b7d93;
+    font-size: 0.9rem;
+    text-align: center;
+  }
+
+  .search-result {
+    display: grid;
+    gap: 0.15rem;
+    padding: 0.55rem 0.65rem;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.1s;
+  }
+
+  .search-result:hover,
+  .search-result.selected {
+    background: #eef3fb;
+  }
+
+  .search-result-name {
+    font-weight: 600;
+    font-size: 0.9rem;
+    color: #1b304a;
+  }
+
+  .search-result-meta {
+    display: flex;
+    gap: 0.6rem;
+    font-size: 0.82rem;
+    color: #5a6f87;
+  }
+
+  .search-result-location {
+    font-weight: 600;
+  }
+
   /* Toast notifications */
   .toast {
     position: fixed;
@@ -899,8 +1104,8 @@
       display: none;
     }
 
-    .grid-nav {
-      flex-wrap: wrap;
+    .search-container {
+      min-width: 0;
     }
   }
 </style>

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { filterReservations } from '$lib/domain/reservations/search';
+import type { Reservation } from '$lib/types';
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+	return {
+		index: 1,
+		firstCellId: 'A|2025-06-01',
+		name: 'John Smith',
+		phoneNumber: '555-1234',
+		notes: '',
+		startDate: '2025-06-01',
+		endDate: '2025-06-05',
+		parkingLocation: 'Site A',
+		color: 'blue',
+		status: 'reserved',
+		...overrides
+	};
+}
+
+const sampleReservations: Reservation[] = [
+	makeReservation({ index: 1, name: 'Alice Johnson', parkingLocation: 'Site A' }),
+	makeReservation({ index: 2, name: 'Bob Smith', parkingLocation: 'Site B' }),
+	makeReservation({ index: 3, name: 'Charlie Brown', parkingLocation: 'Premium Lot' }),
+	makeReservation({ index: 4, name: 'Alice Williams', parkingLocation: 'Site C' }),
+	makeReservation({ index: 5, name: 'David Alice', parkingLocation: 'Site D' })
+];
+
+describe('filterReservations', () => {
+	it('returns empty array for empty query', () => {
+		expect(filterReservations(sampleReservations, '')).toEqual([]);
+	});
+
+	it('returns empty array for whitespace-only query', () => {
+		expect(filterReservations(sampleReservations, '   ')).toEqual([]);
+	});
+
+	it('returns empty array when no reservations match', () => {
+		expect(filterReservations(sampleReservations, 'Zephyr')).toEqual([]);
+	});
+
+	it('matches guest name case-insensitively', () => {
+		const results = filterReservations(sampleReservations, 'alice');
+		const names = results.map((r) => r.reservation.name);
+		expect(names).toContain('Alice Johnson');
+		expect(names).toContain('Alice Williams');
+		expect(names).toContain('David Alice');
+	});
+
+	it('matches parking location case-insensitively', () => {
+		const results = filterReservations(sampleReservations, 'site b');
+		expect(results).toHaveLength(1);
+		expect(results[0].reservation.name).toBe('Bob Smith');
+	});
+
+	it('ranks exact matches above partial matches', () => {
+		const reservations = [
+			makeReservation({ index: 1, name: 'Alice', parkingLocation: 'X' }),
+			makeReservation({ index: 2, name: 'Alice Johnson', parkingLocation: 'Y' }),
+			makeReservation({ index: 3, name: 'Wonderland Alice', parkingLocation: 'Z' })
+		];
+		const results = filterReservations(reservations, 'Alice');
+		expect(results[0].reservation.name).toBe('Alice');
+		expect(results[0].score).toBe(0);
+	});
+
+	it('ranks startsWith matches above contains matches', () => {
+		const reservations = [
+			makeReservation({ index: 1, name: 'Mary Alice', parkingLocation: 'X' }),
+			makeReservation({ index: 2, name: 'Alice Johnson', parkingLocation: 'Y' })
+		];
+		const results = filterReservations(reservations, 'Alice');
+		expect(results[0].reservation.name).toBe('Alice Johnson');
+		expect(results[0].score).toBe(1);
+		expect(results[1].reservation.name).toBe('Mary Alice');
+		expect(results[1].score).toBe(2);
+	});
+
+	it('sorts alphabetically within the same score tier', () => {
+		const results = filterReservations(sampleReservations, 'alice');
+		// Alice Johnson and Alice Williams both startWith 'alice', David Alice contains 'alice'
+		expect(results[0].reservation.name).toBe('Alice Johnson');
+		expect(results[1].reservation.name).toBe('Alice Williams');
+		expect(results[2].reservation.name).toBe('David Alice');
+	});
+
+	it('matches by parking location with exact match scoring', () => {
+		const reservations = [
+			makeReservation({ index: 1, name: 'Guest 1', parkingLocation: 'Premium Lot' }),
+			makeReservation({ index: 2, name: 'Guest 2', parkingLocation: 'Premium' }),
+			makeReservation({ index: 3, name: 'Guest 3', parkingLocation: 'Super Premium' })
+		];
+		const results = filterReservations(reservations, 'Premium');
+		expect(results[0].reservation.parkingLocation).toBe('Premium');
+		expect(results[0].score).toBe(0);
+		expect(results[1].reservation.parkingLocation).toBe('Premium Lot');
+		expect(results[1].score).toBe(1);
+		expect(results[2].reservation.parkingLocation).toBe('Super Premium');
+		expect(results[2].score).toBe(2);
+	});
+
+	it('takes best score when both name and location match', () => {
+		const reservations = [
+			makeReservation({ index: 1, name: 'Site Manager', parkingLocation: 'Site A' })
+		];
+		// 'Site' matches name via startsWith (score 1) and location via startsWith (score 1)
+		const results = filterReservations(reservations, 'Site');
+		expect(results).toHaveLength(1);
+		expect(results[0].score).toBe(1);
+	});
+
+	it('works with empty reservations array', () => {
+		expect(filterReservations([], 'test')).toEqual([]);
+	});
+
+	it('handles single-character query', () => {
+		const results = filterReservations(sampleReservations, 'b');
+		const names = results.map((r) => r.reservation.name);
+		expect(names).toContain('Bob Smith');
+		expect(names).toContain('Charlie Brown');
+	});
+
+	it('trims leading/trailing whitespace from query', () => {
+		const results = filterReservations(sampleReservations, '  bob  ');
+		expect(results).toHaveLength(1);
+		expect(results[0].reservation.name).toBe('Bob Smith');
+	});
+});


### PR DESCRIPTION
## Summary
- Add filterReservations() domain function for client-side search
- Add search input in header with dropdown results
- Results show guest name, site, and dates
- Clicking a result opens the reservation in edit mode

## Test plan
- [ ] Unit tests for search/filter logic (13 new tests)
- [ ] Search by guest name works (case insensitive)
- [ ] Search by site name works
- [ ] Clicking result opens reservation modal
- [ ] Playwright e2e tests pass
- [ ] `npm run check` and `npm run build` pass

> Note: Search input placement may need adjustment after issue 004 (toolbar) merges.