### PR TITLE
fix: install Linux system dependencies for Tauri build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           workspaces: src-tauri
 
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev
+
       - run: npm ci
 
       - name: Build Tauri app


### PR DESCRIPTION
## Summary
- Linux (Ubuntu) build was failing because Tauri v2 requires GTK3, WebKit2GTK, and related system libraries that aren't pre-installed on GitHub runners
- Added `apt-get install` step for the `ubuntu-22.04` matrix entry

## Test plan
- [ ] CI passes
- [ ] Next tag push produces a successful Linux AppImage build