### PR TITLE
fix: resolve Tauri SQLite init race condition

### DIFF
--- a/src/lib/app/composition.ts
+++ b/src/lib/app/composition.ts
@@ -25,6 +25,7 @@ export interface AppServices {
 
 let instance: AppServices | null = null;
 let initPromise: Promise<AppServices> | null = null;
+let properlyInitialized = false;
 
 function isTauri(): boolean {
 	return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
@@ -116,16 +117,18 @@ export function getAppServices(): AppServices {
  * Call this once at app startup before accessing getAppServices().
  */
 export async function initAppServices(): Promise<AppServices> {
-	if (instance) return instance;
+	if (properlyInitialized && instance) return instance;
 
 	if (!initPromise) {
 		initPromise = isTauri()
 			? createSqliteServices().then((services) => {
 					instance = services;
+					properlyInitialized = true;
 					return services;
 				})
 			: Promise.resolve(createLocalStorageServices()).then((services) => {
 					instance = services;
+					properlyInitialized = true;
 					return services;
 				});
 	}

--- a/src/lib/customer-state.ts
+++ b/src/lib/customer-state.ts
@@ -4,13 +4,14 @@ import type { Customer, CustomerFormValues, CustomerSearchResult } from '$lib/do
 
 function createCustomerStore() {
 	const internal = writable<Customer[]>([]);
-	const { customerUseCases } = getAppServices();
 
 	function hydrate(): void {
+		const { customerUseCases } = getAppServices();
 		internal.set(customerUseCases.getAll());
 	}
 
 	function create(form: CustomerFormValues) {
+		const { customerUseCases } = getAppServices();
 		const result = customerUseCases.create(form);
 		if (result.ok) {
 			internal.set(customerUseCases.getAll());
@@ -19,6 +20,7 @@ function createCustomerStore() {
 	}
 
 	function update(form: CustomerFormValues) {
+		const { customerUseCases } = getAppServices();
 		const result = customerUseCases.update(form);
 		if (result.ok) {
 			internal.set(customerUseCases.getAll());
@@ -27,6 +29,7 @@ function createCustomerStore() {
 	}
 
 	function remove(id: string) {
+		const { customerUseCases } = getAppServices();
 		const result = customerUseCases.remove(id);
 		if (result.ok) {
 			internal.set(customerUseCases.getAll());
@@ -35,6 +38,7 @@ function createCustomerStore() {
 	}
 
 	function search(query: string): CustomerSearchResult[] {
+		const { customerUseCases } = getAppServices();
 		return customerUseCases.search(query);
 	}
 
@@ -43,10 +47,12 @@ function createCustomerStore() {
 	}
 
 	function getById(id: string): Customer | null {
+		const { customerUseCases } = getAppServices();
 		return customerUseCases.getById(id);
 	}
 
 	function findOrCreateFromReservation(name: string, phone: string): Customer | null {
+		const { customerUseCases } = getAppServices();
 		const customer = customerUseCases.findOrCreateFromReservation(name, phone);
 		if (customer) {
 			internal.set(customerUseCases.getAll());
@@ -55,12 +61,14 @@ function createCustomerStore() {
 	}
 
 	function importCsv(csvText: string) {
+		const { customerUseCases } = getAppServices();
 		const result = customerUseCases.importCsv(csvText);
 		internal.set(customerUseCases.getAll());
 		return result;
 	}
 
 	function replaceAll(customers: Customer[]): void {
+		const { customerUseCases } = getAppServices();
 		customerUseCases.replaceAll(customers);
 		internal.set(customerUseCases.getAll());
 	}

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -11,17 +11,18 @@ function getDefaultSettings(): SiteSettings {
 }
 
 function createSiteSettingsStore() {
-	const { adminSettingsUseCases } = getAppServices();
 	const internal = writable<SiteSettings>(
-		browser ? adminSettingsUseCases.loadSettings() : getDefaultSettings()
+		browser ? getAppServices().adminSettingsUseCases.loadSettings() : getDefaultSettings()
 	);
 
 	function hydrate(): void {
 		if (!browser) return;
+		const { adminSettingsUseCases } = getAppServices();
 		internal.set(adminSettingsUseCases.loadSettings());
 	}
 
 	function setSiteName(siteName: string): SiteSettings {
+		const { adminSettingsUseCases } = getAppServices();
 		const current = get(internal);
 		const result = adminSettingsUseCases.updateSiteName(siteName, current);
 		if (result.ok && result.settings) {
@@ -32,6 +33,7 @@ function createSiteSettingsStore() {
 	}
 
 	function setCompactView(compact: boolean): SiteSettings {
+		const { adminSettingsUseCases } = getAppServices();
 		const current = get(internal);
 		const result = adminSettingsUseCases.setCompactView(compact, current);
 		internal.set(result.settings);

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -14,12 +14,12 @@ function toRuntimeState(): AppState {
 
 function createRvReservationStore() {
 	const internal = writable<AppState>(toRuntimeState());
-	const { repositories, reservationUseCases, parkingLocationUseCases } = getAppServices();
 
 	function commit(next: AppState, persist = true): void {
 		let finalState = next;
 
 		if (persist) {
+			const { repositories } = getAppServices();
 			const savedAt = repositories.appData.save({
 				version: next.version,
 				reservations: next.reservations,
@@ -63,6 +63,7 @@ function createRvReservationStore() {
 	}
 
 	function saveReservation(formInput: ReservationFormValues): MutationResult {
+		const { reservationUseCases } = getAppServices();
 		const result = reservationUseCases.save(formInput, getPersistedData());
 		if (!result.ok) {
 			return { ok: false, errors: result.errors };
@@ -73,6 +74,7 @@ function createRvReservationStore() {
 	}
 
 	function deleteReservation(index: number): MutationResult {
+		const { reservationUseCases } = getAppServices();
 		const result = reservationUseCases.remove(index, getPersistedData());
 		if (!result.ok) {
 			return { ok: false, errors: result.errors };
@@ -83,6 +85,7 @@ function createRvReservationStore() {
 	}
 
 	function addParkingLocation(nameInput: string): MutationResult {
+		const { parkingLocationUseCases } = getAppServices();
 		const result = parkingLocationUseCases.add(nameInput, getPersistedData());
 		if (!result.ok) {
 			return { ok: false, errors: result.errors };
@@ -93,6 +96,7 @@ function createRvReservationStore() {
 	}
 
 	function renameParkingLocation(oldName: string, newNameInput: string): MutationResult {
+		const { parkingLocationUseCases } = getAppServices();
 		const result = parkingLocationUseCases.rename(oldName, newNameInput, getPersistedData());
 		if (!result.ok) {
 			return { ok: false, errors: result.errors };
@@ -103,6 +107,7 @@ function createRvReservationStore() {
 	}
 
 	function deleteParkingLocation(name: string): MutationResult {
+		const { parkingLocationUseCases } = getAppServices();
 		const result = parkingLocationUseCases.remove(name, getPersistedData());
 		if (!result.ok) {
 			return { ok: false, errors: result.errors };


### PR DESCRIPTION
## Summary
- **Root cause**: Store modules (`state.ts`, `site-settings.ts`, `customer-state.ts`) captured service references at module load time via `getAppServices()`. This ran synchronously before `+layout.ts` could call `initAppServices()` to set up SQLite. Result: the Tauri desktop app silently used localStorage instead of SQLite for all persistence.
- **Why sites didn't persist**: In Tauri's webview, localStorage may not persist across navigations the same way a regular browser does, so parking location add/rename/delete operations appeared to revert.
- **Fix (composition.ts)**: `initAppServices()` now replaces a fallback localStorage instance with the proper SQLite instance when running in Tauri, using a `properlyInitialized` flag.
- **Fix (stores)**: All three store modules now call `getAppServices()` lazily on each operation instead of capturing repos at module creation time. After `initAppServices()` completes and replaces the instance, subsequent operations use the correct SQLite repositories.

## Test plan
- [ ] `npm run check` passes (0 errors, verified locally)
- [ ] `npm run build` passes (verified locally)
- [ ] All 55 Playwright e2e tests pass (verified locally)
- [ ] All 175 unit tests pass (verified locally)
- [ ] Build Tauri app and verify parking location add/rename/delete persists after navigation