### PR TITLE
fix: prevent Tauri window from hanging on close

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.5.1"
+version = "1.5.2"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -351,13 +351,18 @@
     window.addEventListener('beforeunload', handleBeforeUnload);
     document.addEventListener('click', handleSearchClickOutside);
 
-    // In Tauri, intercept window close to flush pending SQLite writes
+    // In Tauri, intercept window close to flush pending SQLite writes.
+    // Use a timeout to guarantee the window closes even if flush hangs.
     let unlistenClose: (() => void) | null = null;
     if ('__TAURI_INTERNALS__' in window) {
       import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
-        getCurrentWindow().onCloseRequested(async (event) => {
+        const appWindow = getCurrentWindow();
+        appWindow.onCloseRequested(async (event) => {
+          event.preventDefault();
           rvReservationStore.forceSave();
-          await flushPendingWrites();
+          const timeout = new Promise<void>((r) => setTimeout(r, 2000));
+          await Promise.race([flushPendingWrites(), timeout]);
+          await appWindow.destroy();
         }).then((unlisten) => {
           unlistenClose = unlisten;
         });


### PR DESCRIPTION
## Summary
v1.5.1 fix for flush-on-close caused the Tauri window to hang indefinitely on Windows because `onCloseRequested` awaited `flushPendingWrites()` without a timeout.

**Fix:** `event.preventDefault()` + `Promise.race` with a 2-second timeout + explicit `appWindow.destroy()`. The window always closes within 2 seconds, and pending writes get up to 2 seconds to complete (more than enough for local SQLite).

## Test plan
- [ ] CI passes
- [ ] Tauri app closes normally on Windows
- [ ] Reservations persist after close + reopen