### PR TITLE
fix: replace broken close handler with continuous flush

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.5.2"
+version = "1.5.3"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -344,6 +344,13 @@
       nowMs = Date.now();
     }, 15 * 60_000);
 
+    // Flush pending SQLite writes every 2 seconds so data is never far behind.
+    // This eliminates the need to intercept window close — even a hard kill
+    // loses at most 2 seconds of work.
+    const flushTicker = window.setInterval(() => {
+      void flushPendingWrites();
+    }, 2_000);
+
     const handleBeforeUnload = (): void => {
       rvReservationStore.forceSave();
     };
@@ -351,31 +358,13 @@
     window.addEventListener('beforeunload', handleBeforeUnload);
     document.addEventListener('click', handleSearchClickOutside);
 
-    // In Tauri, intercept window close to flush pending SQLite writes.
-    // Use a timeout to guarantee the window closes even if flush hangs.
-    let unlistenClose: (() => void) | null = null;
-    if ('__TAURI_INTERNALS__' in window) {
-      import('@tauri-apps/api/window').then(({ getCurrentWindow }) => {
-        const appWindow = getCurrentWindow();
-        appWindow.onCloseRequested(async (event) => {
-          event.preventDefault();
-          rvReservationStore.forceSave();
-          const timeout = new Promise<void>((r) => setTimeout(r, 2000));
-          await Promise.race([flushPendingWrites(), timeout]);
-          await appWindow.destroy();
-        }).then((unlisten) => {
-          unlistenClose = unlisten;
-        });
-      });
-    }
-
     return () => {
       retryTimers.forEach((t) => window.clearTimeout(t));
       window.clearInterval(displayTicker);
       window.clearInterval(autosaveTicker);
+      window.clearInterval(flushTicker);
       window.removeEventListener('beforeunload', handleBeforeUnload);
       document.removeEventListener('click', handleSearchClickOutside);
-      if (unlistenClose) unlistenClose();
       if (toastTimer) clearTimeout(toastTimer);
     };
   });


### PR DESCRIPTION
## Summary
v1.5.2's `onCloseRequested` handler prevented the Tauri window from closing on Windows. The handler called `event.preventDefault()` + `appWindow.destroy()` which fought with Tauri's window lifecycle.

**New approach:** Removed the close handler entirely. Instead, a 2-second `setInterval` continuously flushes pending SQLite writes. The app closes normally (no interception), and at most 2 seconds of work can be lost on a hard kill. SQLite writes take milliseconds, so in practice nothing is lost.

## Test plan
- [ ] CI passes
- [ ] Tauri app closes immediately on all platforms
- [ ] Reservations persist after close + reopen