### PR TITLE
fix: migrate database from old app identifier on first launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.6.0"
+version = "1.6.1"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/app/composition.ts
+++ b/src/lib/app/composition.ts
@@ -76,6 +76,12 @@ async function createSqliteServices(): Promise<AppServices> {
 	const { runMigrations } = await import('$lib/infrastructure/storage/sqlite/migrator');
 	const { allMigrations } = await import('$lib/infrastructure/storage/sqlite/migrations');
 
+	// Migrate database from old app identifier (demo → system) if needed
+	const { migrateLegacyDatabase } = await import(
+		'$lib/infrastructure/storage/sqlite/migrate-legacy-db'
+	);
+	await migrateLegacyDatabase();
+
 	const db = await createTauriDatabase('rv-reservations.db');
 	await runMigrations(db, allMigrations);
 

--- a/src/lib/infrastructure/storage/sqlite/migrate-legacy-db.ts
+++ b/src/lib/infrastructure/storage/sqlite/migrate-legacy-db.ts
@@ -1,0 +1,39 @@
+/**
+ * Migrate the SQLite database from the old app identifier (rv-reservation-demo)
+ * to the new one (rv-reservation-system) if it exists and the new DB is empty.
+ *
+ * This runs once on Tauri startup before the database is opened.
+ */
+export async function migrateLegacyDatabase(): Promise<void> {
+	try {
+		const { appDataDir } = await import('@tauri-apps/api/path');
+		const { exists, copyFile, mkdir } = await import('@tauri-apps/plugin-fs');
+
+		const newDir = await appDataDir();
+		const newDbPath = `${newDir}rv-reservations.db`;
+
+		// Derive the old path by replacing the identifier in the directory
+		const oldDir = newDir.replace(
+			'com.nostoslabs.rv-reservation-system',
+			'com.nostoslabs.rv-reservation-demo'
+		);
+		const oldDbPath = `${oldDir}rv-reservations.db`;
+
+		// Only migrate if old DB exists
+		const oldExists = await exists(oldDbPath);
+		if (!oldExists) return;
+
+		// Only migrate if new DB does NOT exist (don't overwrite)
+		const newExists = await exists(newDbPath);
+		if (newExists) return;
+
+		// Ensure new directory exists
+		await mkdir(newDir, { recursive: true }).catch(() => {});
+
+		await copyFile(oldDbPath, newDbPath);
+		console.log(`Migrated legacy database from ${oldDbPath} to ${newDbPath}`);
+	} catch (err) {
+		// Non-fatal — if migration fails, the app starts with a fresh DB
+		console.warn('Legacy database migration skipped:', err);
+	}
+}


### PR DESCRIPTION
## Summary
When we renamed from `rv-reservation-demo` to `rv-reservation-system` (PR #38), the Tauri app identifier changed. This changed the database directory path, so data from the old app was invisible to new builds.

On first Tauri launch, the app now checks for a database at:
- **macOS**: `~/Library/Application Support/com.nostoslabs.rv-reservation-demo/rv-reservations.db`
- **Windows**: `%APPDATA%\com.nostoslabs.rv-reservation-demo\rv-reservations.db`

If found and the new-path database doesn't exist yet, it copies the old DB over. Non-fatal — if migration fails for any reason, the app starts with a fresh database.

## Test plan
- [ ] CI passes
- [ ] All 100 Playwright tests pass
- [ ] On Mac: delete new DB, run app — old DB data should appear
- [ ] On fresh install with no old data — app starts normally with defaults