### PR TITLE
chore: add tauri:install and tauri:build-and-install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.13.0"
+version = "1.13.1"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary
- Adds `npm run tauri:install` — kills running app, copies built `.app` bundle to `/Applications`
- Adds `npm run tauri:build-and-install` — combined build + install in one command

## Test plan
- [ ] Run `npm run tauri:build-and-install` and verify app appears in `/Applications`
- [ ] Run `npm run tauri:install` while app is running and verify it restarts cleanly