### PR TITLE
fix: use boolean for createUpdaterArtifacts config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.14.1"
+version = "1.14.2"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary
The `createUpdaterArtifacts` value `"v2"` is not valid for Tauri CLI 2.10.0. Changed to `true` which is the correct boolean form. This was causing all release builds (v1.14.0, v1.14.1) to fail.

## Test plan
- [ ] CI passes
- [ ] Release build succeeds after tagging