### PR TITLE
fix: remove duplicate version keys from config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,6 @@
 {
   "name": "rv-reservation-system",
-
-
   "version": "1.15.3",
-
-  "version": "1.15.3",
-
-  "version": "1.15.3",
-
-  "version": "1.15.3",
-
-
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.3"
+version = "1.15.4"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,16 +1,6 @@
 [package]
 name = "rv-reservation-system"
-
-
 version = "1.15.3"
-
-version = "1.15.3"
-
-version = "1.15.3"
-
-version = "1.15.3"
-
-
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,17 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-
-
   "version": "1.15.3",
-
-  "version": "1.15.3",
-
-  "version": "1.15.3",
-
-  "version": "1.15.3",
-
-
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary
Repeated rebase conflict resolutions with `sed` left duplicate `version` entries in `package.json`, `Cargo.toml`, and `tauri.conf.json`, causing Cargo parse failures.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `cargo check` — compiles