### PR TITLE
fix: show actual error message for beta update failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.4"
+version = "1.15.5"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/app/update-checker.ts
+++ b/src/lib/app/update-checker.ts
@@ -95,7 +95,7 @@ export function createUpdateChecker(desktop: DesktopCapabilities): UpdateChecker
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);
 				patch({ downloading: false, available: null, error: `Update failed: ${msg}` });
-				console.error('Update download error:', err);
+				console.error('Update error:', err);
 			}
 		},
 

--- a/src/lib/app/update-checker.ts
+++ b/src/lib/app/update-checker.ts
@@ -93,7 +93,8 @@ export function createUpdateChecker(desktop: DesktopCapabilities): UpdateChecker
 					patch({ downloading: false, available: null, error: 'Update installation failed.' });
 				}
 			} catch (err) {
-				patch({ downloading: false, available: null, error: 'Update download failed.' });
+				const msg = err instanceof Error ? err.message : String(err);
+				patch({ downloading: false, available: null, error: `Update failed: ${msg}` });
 				console.error('Update download error:', err);
 			}
 		},

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -90,14 +90,9 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 			};
 		},
 		async installBetaUpdate(): Promise<boolean> {
-			try {
-				const { invoke } = await import('@tauri-apps/api/core');
-				await invoke('install_beta_update');
-				return true;
-			} catch (err) {
-				console.error('Beta update install failed:', err);
-				return false;
-			}
+			const { invoke } = await import('@tauri-apps/api/core');
+			await invoke('install_beta_update');
+			return true;
 		},
 		async downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
 			if (!pendingUpdate) return false;


### PR DESCRIPTION
## Summary
- Beta update install was catching errors silently and showing generic "Update installation failed"
- Now surfaces the actual Rust updater error message so we can diagnose issues (e.g. signature verification, download failures)

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run test:unit` — 277 pass