### PR TITLE
fix: beta update fails on Mac and Windows due to missing cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.6"
+version = "1.15.7"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,8 +47,12 @@ async fn install_beta_update(app: tauri::AppHandle) -> Result<(), String> {
         .take()
         .ok_or("No pending beta update")?;
 
+    let app_handle = app.clone();
     update
-        .download_and_install(|_bytes, _total| {}, || {})
+        .download_and_install(
+            |_bytes, _total| {},
+            move || { app_handle.cleanup_before_exit(); },
+        )
         .await
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary
The `install_beta_update` Rust command passed a no-op `on_before_exit` callback to `download_and_install()`. The standard Tauri updater plugin calls `app.cleanup_before_exit()` in this callback, which gracefully shuts down the app so the installer can replace the locked binary.

Without it, the installer fails silently on both macOS and Windows because the running app holds file locks on the binary being replaced.

## Fix
Pass `move || { app_handle.cleanup_before_exit(); }` as the `on_before_exit` callback, matching the standard updater plugin's behavior.

## Test plan
- [x] `cargo check` — compiles
- [x] `npm run check` — 0 errors  
- [x] `npm run test:unit` — 277 pass
- [ ] Manual: install beta, enable beta updates, check + install update on Mac
- [ ] Manual: same on Windows