### PR TITLE
fix: beta install shows false failure due to IPC disconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.8",
+  "version": "1.15.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.8"
+version = "1.15.9"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.8",
+  "version": "1.15.9",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -91,7 +91,14 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 		},
 		async installBetaUpdate(): Promise<boolean> {
 			const { invoke } = await import('@tauri-apps/api/core');
-			await invoke('install_beta_update');
+			try {
+				await invoke('install_beta_update');
+			} catch {
+				// The install triggers cleanup_before_exit which can break the
+				// IPC channel before the success response arrives. Treat any
+				// error after invoking as a likely successful install — the
+				// next version check will confirm.
+			}
 			return true;
 		},
 		async downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {


### PR DESCRIPTION
## Summary
The `cleanup_before_exit` callback in the beta update installer can break the IPC channel before the Rust side sends the success response. JS sees a connection error and shows "Update failed" even though the install completed successfully (confirmed by retry showing "up to date").

Fix: catch and ignore errors from the `invoke('install_beta_update')` call. The install always returns `true` — the next version check will confirm whether it actually succeeded.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run test:unit` — 277 pass