### PR TITLE
fix: use standard plugin resource table for beta updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.8",
+  "version": "1.15.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.8"
+version = "1.15.9"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,20 +1,24 @@
-use std::sync::Mutex;
 use tauri::Manager;
 use tauri_plugin_updater::UpdaterExt;
 
-struct BetaUpdate(Mutex<Option<tauri_plugin_updater::Update>>);
-
 #[derive(serde::Serialize)]
-struct BetaUpdateInfo {
+struct BetaUpdateMetadata {
+    rid: u32,
     version: String,
+    #[serde(rename = "currentVersion")]
+    current_version: String,
     body: Option<String>,
+    date: Option<String>,
+    #[serde(rename = "rawJson")]
+    raw_json: serde_json::Value,
 }
 
 #[tauri::command]
 async fn check_beta_update(
-    app: tauri::AppHandle,
+    webview: tauri::WebviewWindow,
     endpoint: String,
-) -> Result<Option<BetaUpdateInfo>, String> {
+) -> Result<Option<BetaUpdateMetadata>, String> {
+    let app = webview.app_handle().clone();
     let url: url::Url = endpoint.parse().map_err(|e: url::ParseError| e.to_string())?;
     let updater = app
         .updater_builder()
@@ -26,35 +30,21 @@ async fn check_beta_update(
     let update = updater.check().await.map_err(|e| e.to_string())?;
     match update {
         Some(update) => {
-            let info = BetaUpdateInfo {
+            let metadata = BetaUpdateMetadata {
+                rid: 0, // placeholder, set below
                 version: update.version.clone(),
+                current_version: update.current_version.clone(),
                 body: update.body.clone(),
+                date: update.date.map(|d| d.to_string()),
+                raw_json: update.raw_json.clone(),
             };
-            *app.state::<BetaUpdate>().0.lock().unwrap() = Some(update);
-            Ok(Some(info))
+            // Store in the webview's resource table so the standard
+            // plugin:updater|download_and_install command can find it.
+            let rid = webview.resources_table().add(update);
+            Ok(Some(BetaUpdateMetadata { rid, ..metadata }))
         }
         None => Ok(None),
     }
-}
-
-#[tauri::command]
-async fn install_beta_update(app: tauri::AppHandle) -> Result<(), String> {
-    let update = app
-        .state::<BetaUpdate>()
-        .0
-        .lock()
-        .unwrap()
-        .take()
-        .ok_or("No pending beta update")?;
-
-    let app_handle = app.clone();
-    update
-        .download_and_install(
-            |_bytes, _total| {},
-            move || { app_handle.cleanup_before_exit(); },
-        )
-        .await
-        .map_err(|e| e.to_string())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -67,11 +57,7 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
-        .manage(BetaUpdate(Mutex::new(None)))
-        .invoke_handler(tauri::generate_handler![
-            check_beta_update,
-            install_beta_update
-        ]);
+        .invoke_handler(tauri::generate_handler![check_beta_update]);
 
     #[cfg(feature = "mcp")]
     {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.8",
+  "version": "1.15.9",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -87,7 +87,10 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 				date: string | null;
 				rawJson: Record<string, unknown>;
 			} | null>('check_beta_update', { endpoint });
-			if (!result) return null;
+			if (!result) {
+				pendingUpdate = null;
+				return null;
+			}
 			// Construct a standard Update object from the resource ID.
 			// This lets downloadAndInstall use the plugin's standard flow
 			// (proper progress events, on_before_exit, Windows process exit).

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -78,21 +78,43 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 		},
 		async checkBetaUpdate(endpoint: string): Promise<UpdateInfo | null> {
 			const { invoke } = await import('@tauri-apps/api/core');
-			const { getVersion } = await import('@tauri-apps/api/app');
-			const currentVersion = await getVersion();
-			const result = await invoke<{ version: string; body: string | null } | null>('check_beta_update', { endpoint });
+			const { Update } = await import('@tauri-apps/plugin-updater');
+			const result = await invoke<{
+				rid: number;
+				version: string;
+				currentVersion: string;
+				body: string | null;
+				date: string | null;
+				rawJson: Record<string, unknown>;
+			} | null>('check_beta_update', { endpoint });
 			if (!result) return null;
+			// Construct a standard Update object from the resource ID.
+			// This lets downloadAndInstall use the plugin's standard flow
+			// (proper progress events, on_before_exit, Windows process exit).
+			pendingUpdate = new Update({
+				...result,
+				date: result.date ?? undefined,
+				body: result.body ?? undefined
+			});
 			return {
 				version: result.version,
-				currentVersion,
-				date: null,
+				currentVersion: result.currentVersion,
+				date: result.date ?? null,
 				body: result.body
 			};
 		},
 		async installBetaUpdate(): Promise<boolean> {
-			const { invoke } = await import('@tauri-apps/api/core');
-			await invoke('install_beta_update');
-			return true;
+			// Beta installs use the same path as stable — the Update object
+			// is in the plugin's resource table, so downloadAndInstall works.
+			if (!pendingUpdate) return false;
+			try {
+				await pendingUpdate.downloadAndInstall();
+				pendingUpdate = null;
+				return true;
+			} catch (err) {
+				console.error('Beta update install failed:', err);
+				return false;
+			}
 		},
 		async downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
 			if (!pendingUpdate) return false;


### PR DESCRIPTION
## Summary
The beta update install was failing on both Mac and Windows because:
1. The `on_download_finish` callback was calling `cleanup_before_exit()` — tearing down app resources *before* install instead of *after*
2. The custom `install_beta_update` Rust command bypassed the plugin's standard lifecycle handling

**Fix:** Store the beta `Update` in the webview's resource table (same as the standard updater). The JS side constructs a standard `Update` object from the returned resource ID, so `downloadAndInstall()` uses the plugin's standard flow — proper progress events, correct `on_before_exit` lifecycle, and correct Windows process exit handling.

This removes the `install_beta_update` Rust command and `BetaUpdate` state entirely.

## Test plan
- [x] `cargo check` — compiles
- [x] `npm run check` — 0 errors
- [x] `npm run test:unit` — 277 pass
- [x] `npm run build` — success
- [ ] Manual: beta update install on Mac
- [ ] Manual: beta update install on Windows