### PR TITLE
fix: beta setting not persisting + unify update install path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.10",
+  "version": "1.15.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.10"
+version = "1.15.11"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.10",
+  "version": "1.15.11",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/app/update-checker.ts
+++ b/src/lib/app/update-checker.ts
@@ -13,7 +13,7 @@ export interface UpdateState {
 export interface UpdateChecker {
 	state: Readable<UpdateState>;
 	checkForUpdate(beta?: boolean): Promise<void>;
-	downloadAndInstall(beta?: boolean): Promise<void>;
+	downloadAndInstall(): Promise<void>;
 	relaunch(): Promise<void>;
 }
 
@@ -73,20 +73,15 @@ export function createUpdateChecker(desktop: DesktopCapabilities): UpdateChecker
 			}
 		},
 
-		async downloadAndInstall(beta?: boolean) {
+		async downloadAndInstall() {
 			patch({ downloading: true, downloadProgress: 0, error: null });
 			try {
-				let ok: boolean;
-				if (beta) {
-					ok = await desktop.installBetaUpdate();
-				} else {
-					ok = await desktop.downloadAndInstallUpdate((progress) => {
-						if (progress.contentLength && progress.contentLength > 0) {
-							const pct = Math.round((progress.downloadedLength / progress.contentLength) * 100);
-							patch({ downloadProgress: Math.min(pct, 100) });
-						}
-					});
-				}
+				const ok = await desktop.downloadAndInstallUpdate((progress) => {
+					if (progress.contentLength && progress.contentLength > 0) {
+						const pct = Math.round((progress.downloadedLength / progress.contentLength) * 100);
+						patch({ downloadProgress: Math.min(pct, 100) });
+					}
+				});
 				if (ok) {
 					patch({ downloading: false, downloadProgress: 100, installed: true });
 				} else {

--- a/src/lib/application/ports/desktop.ts
+++ b/src/lib/application/ports/desktop.ts
@@ -50,9 +50,6 @@ export interface DesktopCapabilities {
 	/** Download and install an available update. Returns true on success. */
 	downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean>;
 
-	/** Download and install a pending beta update. Returns true on success. */
-	installBetaUpdate(): Promise<boolean>;
-
 	/** Relaunch the application after an update has been installed. */
 	relaunch(): Promise<void>;
 }

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -106,19 +106,6 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 				body: result.body
 			};
 		},
-		async installBetaUpdate(): Promise<boolean> {
-			// Beta installs use the same path as stable — the Update object
-			// is in the plugin's resource table, so downloadAndInstall works.
-			if (!pendingUpdate) return false;
-			try {
-				await pendingUpdate.downloadAndInstall();
-				pendingUpdate = null;
-				return true;
-			} catch (err) {
-				console.error('Beta update install failed:', err);
-				return false;
-			}
-		},
 		async downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
 			if (!pendingUpdate) return false;
 			try {

--- a/src/lib/infrastructure/desktop/web-fallback.ts
+++ b/src/lib/infrastructure/desktop/web-fallback.ts
@@ -41,9 +41,6 @@ export function createWebFallbackDesktopCapabilities(): DesktopCapabilities {
 		async downloadAndInstallUpdate() {
 			return false;
 		},
-		async installBetaUpdate() {
-			return false;
-		},
 		async relaunch() {},
 		async openFile(filters?: FileFilter[]): Promise<string | null> {
 			return new Promise((resolve) => {

--- a/src/lib/infrastructure/storage/sqlite/site-settings-repository.ts
+++ b/src/lib/infrastructure/storage/sqlite/site-settings-repository.ts
@@ -22,7 +22,7 @@ function sanitize(settings: SiteSettings): SiteSettings {
 	const siteName =
 		settings.siteName?.trim().slice(0, 80) || DEFAULT_SITE_NAME;
 	const autoBackup = settings.autoBackup ?? defaultAutoBackup();
-	return { siteName, compactView: settings.compactView, autoBackup };
+	return { siteName, compactView: settings.compactView, autoBackup, betaUpdates: settings.betaUpdates };
 }
 
 async function loadFromDb(db: Database): Promise<SiteSettings> {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -477,13 +477,11 @@
             </button>
           {:else if $updateState.downloading}
             <div class="update-status" data-testid="update-downloading">
-              {$siteSettingsStore.betaUpdates ? 'Installing beta update...' : `Downloading update... ${$updateState.downloadProgress}%`}
+              Downloading update... {$updateState.downloadProgress}%
             </div>
-            {#if !$siteSettingsStore.betaUpdates}
-              <div class="progress-bar">
-                <div class="progress-fill" style="width: {$updateState.downloadProgress}%"></div>
-              </div>
-            {/if}
+            <div class="progress-bar">
+              <div class="progress-fill" style="width: {$updateState.downloadProgress}%"></div>
+            </div>
           {:else if $updateState.available}
             <div class="update-status" data-testid="update-available">
               Update available: v{$updateState.available.version}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -491,7 +491,7 @@
                 <span class="beta-badge">Beta</span>
               {/if}
             </div>
-            <button type="button" class="primary" on:click={() => updateChecker.downloadAndInstall($siteSettingsStore.betaUpdates)} data-testid="update-download-btn">
+            <button type="button" class="primary" on:click={() => updateChecker.downloadAndInstall()} data-testid="update-download-btn">
               Download &amp; Install
             </button>
           {:else if $updateState.checking}

--- a/tests/unit/auto-backup.test.ts
+++ b/tests/unit/auto-backup.test.ts
@@ -59,7 +59,6 @@ describe('startAutoBackupTimer', () => {
 				checkForUpdate: async () => null,
 				checkBetaUpdate: async () => null,
 				downloadAndInstallUpdate: async () => false,
-				installBetaUpdate: async () => false,
 				relaunch: async () => {}
 			},
 			onSuccess: async () => {},
@@ -111,7 +110,6 @@ describe('startAutoBackupTimer', () => {
 				checkForUpdate: async () => null,
 				checkBetaUpdate: async () => null,
 				downloadAndInstallUpdate: async () => false,
-				installBetaUpdate: async () => false,
 				relaunch: async () => {}
 			}
 		});

--- a/tests/unit/startup-migrations.test.ts
+++ b/tests/unit/startup-migrations.test.ts
@@ -15,7 +15,6 @@ function makeStubServices(): AppServices {
 			checkForUpdate: async () => null,
 			checkBetaUpdate: async () => null,
 			downloadAndInstallUpdate: async () => false,
-			installBetaUpdate: async () => false,
 			relaunch: async () => {}
 		},
 		repositories: {

--- a/tests/unit/update-checker.test.ts
+++ b/tests/unit/update-checker.test.ts
@@ -15,7 +15,6 @@ function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapab
 		checkForUpdate: async () => null,
 		checkBetaUpdate: async () => null,
 		downloadAndInstallUpdate: async () => false,
-		installBetaUpdate: async () => false,
 		relaunch: async () => {},
 		...overrides
 	};


### PR DESCRIPTION
## Summary
1. **Beta setting didn't persist**: `sanitize()` in the SQLite site-settings repo was stripping `betaUpdates` before saving — always reverted to false on restart
2. **Unified install path**: Removed separate `installBetaUpdate()` method. Since the beta check now stores a standard `Update` in the resource table, both stable and beta use the same `downloadAndInstallUpdate()` with proper progress events

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run test:unit` — 277 pass
- [x] `npm run build` — success
- [ ] Manual: enable beta, restart app, verify setting persists
- [ ] Manual: beta update install with progress bar