### PR TITLE
chore: version bump for beta update testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.11",
+  "version": "1.15.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.11"
+version = "1.15.12"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.11",
+  "version": "1.15.12",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
Version bump to 1.15.12 so v1.15.11 users can test the unified beta update flow.