### PR TITLE
fix: surface actual updater error in UI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+When reviewing pull requests in this repository, prioritize maintainability, modularity, correctness, and testability.
+
+## Review goals
+- Flag violations of single responsibility, high coupling, unclear boundaries, or mixed domain/infrastructure/UI concerns.
+- Flag brittle code, hidden side effects, duplicated logic, tight coupling, poor naming, overly large functions/modules, and unclear ownership of behavior.
+- Prefer simple, explicit designs over clever or overly abstract ones.
+- Prefer changes that reduce complexity and improve modularity without unnecessary indirection.
+- Identify code that is difficult to test because of hidden dependencies, global state, side effects, or missing seams.
+
+## Architecture guidance
+- Encourage clear separation of domain logic, application orchestration, infrastructure, and UI concerns.
+- Prefer dependency inversion at architectural boundaries.
+- Flag business logic embedded in transport, persistence, or UI layers.
+- Flag abstractions that add indirection without reducing complexity.
+
+## Testing guidance
+- Verify that new or changed behavior is covered by appropriate tests.
+- Do not suggest changing tests merely to satisfy implementation changes unless behavior intentionally changed and the PR explains why.
+- Flag missing regression tests for bug fixes.
+- Flag code that is difficult to test and explain what design change would improve testability.
+
+## Review focus
+Prioritize the highest-impact issues:
+1. correctness and safety
+2. architecture and maintainability
+3. testability and regression risk
+4. readability and duplication
+5. performance only when there is a clear issue
+
+## Review output
+For each issue:
+- state the problem clearly
+- explain why it matters
+- point to the affected code
+- suggest a concrete improvement
+
+Only comment on substantive issues. Avoid trivial style comments unless they affect readability or correctness.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.12",
+  "version": "1.15.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.12"
+version = "1.15.13"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.12",
+  "version": "1.15.13",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -108,26 +108,21 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 		},
 		async downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
 			if (!pendingUpdate) return false;
-			try {
-				let totalLength: number | null = null;
-				let downloaded = 0;
-				await pendingUpdate.downloadAndInstall((event) => {
-					if (!onProgress || !event.data) return;
-					if (event.event === 'Started') {
-						totalLength = (event.data.contentLength as number) ?? null;
-						downloaded = 0;
-					} else if (event.event === 'Progress') {
-						const chunk = (event.data.chunkLength as number) ?? 0;
-						downloaded += chunk;
-						onProgress({ downloadedLength: downloaded, contentLength: totalLength });
-					}
-				});
-				pendingUpdate = null;
-				return true;
-			} catch (err) {
-				console.error('Update install failed:', err);
-				return false;
-			}
+			let totalLength: number | null = null;
+			let downloaded = 0;
+			await pendingUpdate.downloadAndInstall((event) => {
+				if (!onProgress || !event.data) return;
+				if (event.event === 'Started') {
+					totalLength = (event.data.contentLength as number) ?? null;
+					downloaded = 0;
+				} else if (event.event === 'Progress') {
+					const chunk = (event.data.chunkLength as number) ?? 0;
+					downloaded += chunk;
+					onProgress({ downloadedLength: downloaded, contentLength: totalLength });
+				}
+			});
+			pendingUpdate = null;
+			return true;
 		},
 		async relaunch(): Promise<void> {
 			const { relaunch } = await import('@tauri-apps/plugin-process');


### PR DESCRIPTION
Remove try/catch so updater errors show the real message instead of generic 'Update installation failed.'