### PR TITLE
feat: add GitHub Copilot review instructions

### DIFF
--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "**/*.rs"
+---
+
+# Rust review guidelines
+
+- Prefer strong typing and ownership-aware design over unnecessary cloning or shared mutable state.
+- Flag large modules, god structs, or traits with unrelated responsibilities.
+- Flag Result/Option handling that obscures failure paths.
+- Prefer explicit error handling and meaningful error types.
+- Flag business rules mixed into HTTP handlers, database code, or serialization layers.
+- Flag code that makes unit testing hard because dependencies are not injectable or side effects are not isolated.
+- Prefer straightforward composition over premature generic abstractions.

--- a/.github/instructions/svelte.instructions.md
+++ b/.github/instructions/svelte.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: "**/*.svelte"
+---
+
+# Svelte review guidelines
+
+- Keep UI components focused on presentation and simple interaction logic.
+- Flag domain or persistence logic embedded directly in components.
+- Prefer moving reusable business logic into stores, services, or domain modules.
+- Flag state management that is overly coupled, hard to reason about, or hard to test.
+- Flag accessibility issues for interactive elements, forms, labels, keyboard support, and ARIA usage where relevant.
+- Prefer components that are easy to test with clear inputs, outputs, and side effects.

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "**/*.{ts,tsx}"
+---
+
+# TypeScript review guidelines
+
+- Prefer explicit types at module boundaries.
+- Flag use of any, implicit contracts, or unsafe casts unless clearly justified.
+- Flag overly large services, utility dumping grounds, and mixed concerns.
+- Prefer small composable modules with clear responsibilities.
+- Flag duplication that should be extracted, but avoid abstractions that hide simple logic.
+- Ensure async flows, error handling, and null/undefined handling are explicit and testable.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.13",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.13"
+version = "1.16.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.13",
+  "version": "1.16.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -108,21 +108,26 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 		},
 		async downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
 			if (!pendingUpdate) return false;
-			let totalLength: number | null = null;
-			let downloaded = 0;
-			await pendingUpdate.downloadAndInstall((event) => {
-				if (!onProgress || !event.data) return;
-				if (event.event === 'Started') {
-					totalLength = (event.data.contentLength as number) ?? null;
-					downloaded = 0;
-				} else if (event.event === 'Progress') {
-					const chunk = (event.data.chunkLength as number) ?? 0;
-					downloaded += chunk;
-					onProgress({ downloadedLength: downloaded, contentLength: totalLength });
-				}
-			});
-			pendingUpdate = null;
-			return true;
+			try {
+				let totalLength: number | null = null;
+				let downloaded = 0;
+				await pendingUpdate.downloadAndInstall((event) => {
+					if (!onProgress || !event.data) return;
+					if (event.event === 'Started') {
+						totalLength = (event.data.contentLength as number) ?? null;
+						downloaded = 0;
+					} else if (event.event === 'Progress') {
+						const chunk = (event.data.chunkLength as number) ?? 0;
+						downloaded += chunk;
+						onProgress({ downloadedLength: downloaded, contentLength: totalLength });
+					}
+				});
+				pendingUpdate = null;
+				return true;
+			} catch (err) {
+				console.error('Update install failed:', err);
+				return false;
+			}
 		},
 		async relaunch(): Promise<void> {
 			const { relaunch } = await import('@tauri-apps/plugin-process');


### PR DESCRIPTION
## Summary
- Add repo-level Copilot instructions (`.github/copilot-instructions.md`) for PR review guidance
- Add language-specific instruction files for Rust, Svelte, and TypeScript with `applyTo` frontmatter
- Remove misnamed wildcard file (`*.instructions.md`) that didn't match GitHub's naming convention

## Test plan
- [ ] Verify files appear under repo Settings > Copilot > Instructions
- [ ] Confirm Copilot code review references the instructions on a test PR