### PR TITLE
fix: surface update errors + load .env for local signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.15",
+  "version": "1.15.16",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "test:e2e": "npx playwright test",
     "tauri": "tauri",
     "tauri:dev": "npx tauri dev",
-    "tauri:build": "npx tauri build",
+    "tauri:build": "export $(grep -v '^#' .env | xargs) && npx tauri build",
     "tauri:install": "pkill -x 'RV Reservation System' 2>/dev/null; sleep 1; rm -rf '/Applications/RV Reservation System.app' && cp -R 'src-tauri/target/release/bundle/macos/RV Reservation System.app' /Applications/ && echo 'Installed to /Applications'",
     "tauri:build-and-install": "npm run tauri:build && npm run tauri:install",
     "deploy": "npx vercel --prod"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.15"
+version = "1.15.16"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.15",
+  "version": "1.15.16",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -107,27 +107,22 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 			};
 		},
 		async downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
-			if (!pendingUpdate) return false;
-			try {
-				let totalLength: number | null = null;
-				let downloaded = 0;
-				await pendingUpdate.downloadAndInstall((event) => {
-					if (!onProgress || !event.data) return;
-					if (event.event === 'Started') {
-						totalLength = (event.data.contentLength as number) ?? null;
-						downloaded = 0;
-					} else if (event.event === 'Progress') {
-						const chunk = (event.data.chunkLength as number) ?? 0;
-						downloaded += chunk;
-						onProgress({ downloadedLength: downloaded, contentLength: totalLength });
-					}
-				});
-				pendingUpdate = null;
-				return true;
-			} catch (err) {
-				console.error('Update install failed:', err);
-				return false;
-			}
+			if (!pendingUpdate) throw new Error('No pending update to install');
+			let totalLength: number | null = null;
+			let downloaded = 0;
+			await pendingUpdate.downloadAndInstall((event) => {
+				if (!onProgress || !event.data) return;
+				if (event.event === 'Started') {
+					totalLength = (event.data.contentLength as number) ?? null;
+					downloaded = 0;
+				} else if (event.event === 'Progress') {
+					const chunk = (event.data.chunkLength as number) ?? 0;
+					downloaded += chunk;
+					onProgress({ downloadedLength: downloaded, contentLength: totalLength });
+				}
+			});
+			pendingUpdate = null;
+			return true;
 		},
 		async relaunch(): Promise<void> {
 			const { relaunch } = await import('@tauri-apps/plugin-process');


### PR DESCRIPTION
Surface actual Tauri updater errors in UI instead of generic message. Load .env for TAURI_SIGNING_PRIVATE_KEY in local builds.