### PR TITLE
fix: correct updater pubkey to match signing key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.19",
+  "version": "1.15.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.19"
+version = "1.15.20"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDYxQjZGNDlFOUU1MkI0RTIKUldUaXRGS2VudlMyWWFMVHVDdWQ2ci9PRGI4MnZFWWgwSFp1MWVncUhBNTFSMU5nZ3MyVVJYcnkK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEQzQ0RGMDU2QjU5NTY4QUEKUldTcWFKVzFWdkROMDhKRlZjelhBeE9lRTMrQ1NMOEZtNDQ4eUQ1YnIvZklZWWdqWHMwVG1rVVEK",
       "endpoints": [
         "https://github.com/nostoslabs/rv-reservation-system/releases/latest/download/latest.json"
       ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.19",
+  "version": "1.15.20",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
The pubkey in tauri.conf.json was from a different keypair than the TAURI_SIGNING_PRIVATE_KEY used in CI. All releases were signed correctly, but the app couldn't verify them. This updates the pubkey to match.