### PR TITLE
release: v1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.15.2",
+      "version": "1.16.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.15.21",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.15.21"
+version = "1.16.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.15.21",
+  "version": "1.16.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Stable release v1.16.0

Everything since v1.14.2 (last client release):

### New Features
- Beta update channel with opt-in setting and confirmation dialog (#92)

### Bug Fixes
- Undo delete now restores customers and reservations correctly (#90)
- Atomic backup restore with snapshot/rollback (#90)
- Reservation names truncated to "..." in compact view (#91)
- TODAY button aligns to left edge (#97)
- Customer search dropdown hidden behind grid (#98)
- Status colors darkened for colorblind accessibility (#99)
- Beta update signing key and persistence fixes (#106, #108, #114, #120)
- Surface actual updater error messages in UI (#111)

### Infrastructure
- Release workflow creates pre-releases for -beta/-rc tags
- Local builds source .env for signing key
- Correct updater pubkey matching signing private key