### PR TITLE
fix: strengthen today column indicator to survive status colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.16.0"
+version = "1.16.1"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1231,7 +1231,6 @@
 
   .grid-cell.today {
     background: rgba(10, 99, 224, 0.05);
-    box-shadow: inset 3px 0 0 0 #0a63e0, inset -3px 0 0 0 #0a63e0;
   }
 
   .grid-cell.today::after {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1194,7 +1194,7 @@
   .date-header.today {
     background: rgba(10, 99, 224, 0.12);
     color: #0a63e0;
-    box-shadow: inset 0 -3px 0 0 #0a63e0;
+    box-shadow: inset 0 -4px 0 0 #0a63e0, inset 0 4px 0 0 #0a63e0;
   }
 
   .location-cell {
@@ -1231,8 +1231,19 @@
 
   .grid-cell.today {
     background: rgba(10, 99, 224, 0.05);
-    border-left: 1px solid rgba(10, 99, 224, 0.18);
-    border-right: 1px solid rgba(10, 99, 224, 0.18);
+    box-shadow: inset 3px 0 0 0 #0a63e0, inset -3px 0 0 0 #0a63e0;
+  }
+
+  .grid-cell.today::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    box-shadow: inset 3px 0 0 0 #0a63e0, inset -3px 0 0 0 #0a63e0;
+    pointer-events: none;
+    z-index: 1;
   }
 
   .grid-cell.today:hover {

--- a/tests/e2e/today-column.spec.ts
+++ b/tests/e2e/today-column.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function resetApp(page: Page) {
+	await page.goto('/');
+	await page.evaluate(() => window.localStorage.clear());
+	await page.reload();
+	await page.waitForSelector('.toolbar-title');
+	await page.waitForTimeout(300);
+}
+
+function offsetDate(days: number): string {
+	const d = new Date();
+	d.setDate(d.getDate() + days);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const dd = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${dd}`;
+}
+
+const modal = (page: Page) => page.locator('.modal[role="dialog"]');
+
+async function clickCellAtDate(page: Page, dateIso: string, rowIndex = 0) {
+	const colIndex = await page.evaluate((date) => {
+		const headers = document.querySelectorAll('th.date-header[data-date]');
+		for (let i = 0; i < headers.length; i++) {
+			if (headers[i].getAttribute('data-date') === date) return i;
+		}
+		return -1;
+	}, dateIso);
+	if (colIndex === -1) throw new Error(`Date column ${dateIso} not found in grid`);
+
+	const cell = page.locator('tbody tr').nth(rowIndex).locator('td.grid-cell').nth(colIndex);
+	await cell.scrollIntoViewIfNeeded();
+	return cell;
+}
+
+async function createReservation(
+	page: Page,
+	opts: { name: string; startDate: string; endDate: string; rowIndex?: number; status?: string }
+) {
+	const cell = await clickCellAtDate(page, opts.startDate, opts.rowIndex ?? 0);
+	await cell.click();
+	await expect(modal(page)).toBeVisible();
+
+	await modal(page).locator('[data-testid="guest-name-input"]').fill(opts.name);
+	await modal(page).locator('input[type="date"]').first().fill(opts.startDate);
+	await modal(page).locator('input[type="date"]').nth(1).fill(opts.endDate);
+
+	if (opts.status) {
+		await modal(page).locator('select[aria-label="Reservation status"]').selectOption(opts.status);
+	}
+
+	await modal(page).locator('button[type="submit"]').click();
+	await expect(modal(page)).not.toBeVisible();
+}
+
+test.describe('Today column indicator', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('today header has prominent indicator styling', async ({ page }) => {
+		const todayHeader = page.locator('th.date-header.today');
+		await todayHeader.scrollIntoViewIfNeeded();
+
+		// Header should have distinct background color (not default)
+		const headerBg = await todayHeader.evaluate((el) => getComputedStyle(el).backgroundColor);
+		expect(headerBg).not.toBe('rgb(255, 255, 255)');
+
+		// Header should have box-shadow (top + bottom bars)
+		const headerShadow = await todayHeader.evaluate((el) => getComputedStyle(el).boxShadow);
+		expect(headerShadow).not.toBe('none');
+	});
+
+	test('today cells have ::after pseudo-element indicator even when occupied', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(2);
+
+		// Fill today's column with reservations across multiple sites
+		await createReservation(page, { name: 'Guest A', startDate: today, endDate, rowIndex: 0, status: 'reserved' });
+		await createReservation(page, { name: 'Guest B', startDate: today, endDate, rowIndex: 1, status: 'checked-in' });
+		await createReservation(page, { name: 'Guest C', startDate: today, endDate, rowIndex: 2, status: 'alert' });
+
+		// Get an occupied today cell
+		const occupiedTodayCell = page.locator('.grid-cell.today.occupied').first();
+		await occupiedTodayCell.scrollIntoViewIfNeeded();
+
+		// The ::after pseudo-element adds box-shadow indicators that survive inline status styles.
+		// Verify the cell has box-shadow (set via ::after or directly on .grid-cell.today)
+		const cellShadow = await occupiedTodayCell.evaluate((el) => getComputedStyle(el).boxShadow);
+		expect(cellShadow).not.toBe('none');
+	});
+
+	test('screenshot: today column visible with occupied cells', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(2);
+
+		// Fill several rows on today
+		await createReservation(page, { name: 'Guest A', startDate: today, endDate, rowIndex: 0 });
+		await createReservation(page, { name: 'Guest B', startDate: today, endDate, rowIndex: 1 });
+		await createReservation(page, { name: 'Guest C', startDate: today, endDate, rowIndex: 2 });
+
+		// Scroll to today
+		await page.click('[data-testid="today-button"]');
+		await page.waitForTimeout(300);
+
+		await page.screenshot({ path: 'screenshots/today-column-indicator.png', fullPage: false });
+	});
+});


### PR DESCRIPTION
## Summary
- Uses `::after` pseudo-element with `box-shadow` to draw thick blue side indicators on today's grid cells
- These persist even when inline status styles override `background-color` and `border-left`
- Strengthens date header indicator with both top and bottom 4px bars

## Why
When all sites are occupied, status colors applied via inline `style=` override the subtle `.grid-cell.today` CSS background and borders. Today's column becomes invisible. The `::after` pseudo-element and `box-shadow` properties are unaffected by inline styles, making the indicator always visible.

## Test plan
- [ ] Verify today column has thick blue side indicators visible on all rows
- [ ] Verify indicators persist when cells have status colors (reserved, checked-in, etc.)
- [ ] Verify date header has top and bottom blue bars
- [ ] Verify drag/drop still works on today column cells