### PR TITLE
fix: prevent autocomplete dropdown from opening on edit modal focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.16.0",
+      "version": "1.16.2",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.16.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.16.0"
+version = "1.16.2"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.16.0",
+  "version": "1.16.2",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/components/AutocompleteInput.svelte
+++ b/src/lib/components/AutocompleteInput.svelte
@@ -92,10 +92,12 @@
     }
   }
 
-  export function focus(): void {
-    dismissed = true;
-    dropdownOpen = false;
-    selectedIndex = -1;
+  export function focus(options?: { suppressDropdown?: boolean }): void {
+    if (options?.suppressDropdown) {
+      dismissed = true;
+      dropdownOpen = false;
+      selectedIndex = -1;
+    }
     inputEl?.focus();
   }
 </script>

--- a/src/lib/components/AutocompleteInput.svelte
+++ b/src/lib/components/AutocompleteInput.svelte
@@ -94,6 +94,8 @@
 
   export function focus(): void {
     dismissed = true;
+    dropdownOpen = false;
+    selectedIndex = -1;
     inputEl?.focus();
   }
 </script>

--- a/src/lib/components/AutocompleteInput.svelte
+++ b/src/lib/components/AutocompleteInput.svelte
@@ -93,6 +93,7 @@
   }
 
   export function focus(): void {
+    dismissed = true;
     inputEl?.focus();
   }
 </script>

--- a/src/lib/components/ReservationModal.svelte
+++ b/src/lib/components/ReservationModal.svelte
@@ -80,7 +80,7 @@
   afterUpdate(() => {
     // Focus guest name input when modal just opened
     if (open && !wasOpen && autocompleteRef) {
-      autocompleteRef.focus();
+      autocompleteRef.focus({ suppressDropdown: mode === 'edit' });
     }
     wasOpen = open;
   });

--- a/tests/e2e/edit-modal-autocomplete.spec.ts
+++ b/tests/e2e/edit-modal-autocomplete.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function resetApp(page: Page) {
+	await page.goto('/');
+	await page.evaluate(() => window.localStorage.clear());
+	await page.reload();
+	await page.waitForSelector('.toolbar-title');
+	await page.waitForTimeout(300);
+}
+
+function offsetDate(days: number): string {
+	const d = new Date();
+	d.setDate(d.getDate() + days);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const dd = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${dd}`;
+}
+
+const modal = (page: Page) => page.locator('.modal[role="dialog"]');
+
+async function clickCellAtDate(page: Page, dateIso: string, rowIndex = 0) {
+	const colIndex = await page.evaluate((date) => {
+		const headers = document.querySelectorAll('th.date-header[data-date]');
+		for (let i = 0; i < headers.length; i++) {
+			if (headers[i].getAttribute('data-date') === date) return i;
+		}
+		return -1;
+	}, dateIso);
+	if (colIndex === -1) throw new Error(`Date column ${dateIso} not found in grid`);
+
+	const cell = page.locator('tbody tr').nth(rowIndex).locator('td.grid-cell').nth(colIndex);
+	await cell.scrollIntoViewIfNeeded();
+	await cell.click();
+}
+
+async function createReservation(
+	page: Page,
+	opts: { name: string; phone?: string; startDate: string; endDate: string; rowIndex?: number }
+) {
+	await clickCellAtDate(page, opts.startDate, opts.rowIndex ?? 0);
+	await expect(modal(page)).toBeVisible();
+
+	await modal(page).locator('[data-testid="guest-name-input"]').fill(opts.name);
+	await modal(page).locator('input[type="date"]').first().fill(opts.startDate);
+	await modal(page).locator('input[type="date"]').nth(1).fill(opts.endDate);
+	if (opts.phone) {
+		await modal(page).locator('input[type="tel"]').fill(opts.phone);
+	}
+
+	await modal(page).locator('button[type="submit"]').click();
+	await expect(modal(page)).not.toBeVisible();
+}
+
+test.describe('Edit modal autocomplete dropdown', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('dropdown does NOT appear when opening edit modal', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(3);
+
+		// Create a reservation and a customer
+		await createReservation(page, { name: 'Alice Johnson', phone: '555-1234', startDate: today, endDate });
+
+		// Click the occupied cell to open edit modal
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.scrollIntoViewIfNeeded();
+		await occupied.click();
+		await expect(modal(page)).toBeVisible();
+
+		// Wait for the modal to settle (focus fires on open)
+		await page.waitForTimeout(300);
+
+		// The autocomplete dropdown should NOT be visible
+		const dropdown = modal(page).locator('.autocomplete-dropdown');
+		await expect(dropdown).toBeHidden();
+	});
+
+	test('dropdown appears when user types in name field on edit modal', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(3);
+
+		// Create a reservation and customer
+		await createReservation(page, { name: 'Alice Johnson', phone: '555-1234', startDate: today, endDate });
+
+		// Open edit modal
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.scrollIntoViewIfNeeded();
+		await occupied.click();
+		await expect(modal(page)).toBeVisible();
+		await page.waitForTimeout(300);
+
+		// Now type in the name field — dropdown should appear
+		const nameInput = modal(page).locator('[data-testid="guest-name-input"]');
+		await nameInput.clear();
+		await nameInput.type('Alice');
+
+		const dropdown = modal(page).locator('.autocomplete-dropdown');
+		await expect(dropdown).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary
- Sets `dismissed = true` in AutocompleteInput's `focus()` method
- Prevents the suggestion dropdown from appearing when the edit modal opens and programmatically focuses the name field
- User must actively type to trigger the dropdown, which resets `dismissed` via `handleInput()`

## Why
When opening the edit modal, the name field is auto-focused and already contains the guest's name. This caused the autocomplete dropdown to immediately appear, which was distracting and unnecessary.

## Test plan
- [ ] Open edit modal for an existing reservation — dropdown should NOT appear
- [ ] Click into the name field and type a character — dropdown should appear with suggestions
- [ ] Create a new reservation — autocomplete should work normally when typing a name