### PR TITLE
feat: add RV type to reservation search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.16.0"
+version = "1.17.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/domain/reservations/search.ts
+++ b/src/lib/domain/reservations/search.ts
@@ -15,7 +15,7 @@ function stripNonDigits(value: string): string {
 
 /**
  * Filter reservations by a search query, matching against guest name, parking location,
- * and phone number.
+ * RV type, and phone number.
  * Returns results sorted by relevance: exact match first, then startsWith, then contains.
  * Within the same relevance tier, results are sorted alphabetically by guest name.
  *
@@ -54,6 +54,18 @@ export function filterReservations(
 			bestScore = Math.min(bestScore, 1);
 		} else if (lowerLocation.includes(lowerQuery)) {
 			bestScore = Math.min(bestScore, 2);
+		}
+
+		// Check RV type
+		if (reservation.rvType) {
+			const lowerRvType = reservation.rvType.toLowerCase();
+			if (lowerRvType === lowerQuery) {
+				bestScore = Math.min(bestScore, 0);
+			} else if (lowerRvType.startsWith(lowerQuery)) {
+				bestScore = Math.min(bestScore, 1);
+			} else if (lowerRvType.includes(lowerQuery)) {
+				bestScore = Math.min(bestScore, 2);
+			}
 		}
 
 		// Check phone number (digits-only comparison for flexible matching)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -603,6 +603,9 @@
                 <span class="search-result-name">{result.reservation.name}</span>
                 <span class="search-result-meta">
                   <span class="search-result-location">{result.reservation.parkingLocation}</span>
+                  {#if result.reservation.rvType}
+                    <span class="search-result-rvtype">{result.reservation.rvType}</span>
+                  {/if}
                   {#if result.reservation.phoneNumber}
                     <span class="search-result-phone">{result.reservation.phoneNumber}</span>
                   {/if}
@@ -1397,6 +1400,10 @@
 
   .search-result-location {
     font-weight: 600;
+  }
+
+  .search-result-rvtype {
+    color: #6b7d93;
   }
 
   .search-result-phone {

--- a/tests/e2e/rv-type-search.spec.ts
+++ b/tests/e2e/rv-type-search.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function resetApp(page: Page) {
+	await page.goto('/');
+	await page.evaluate(() => window.localStorage.clear());
+	await page.reload();
+	await page.waitForSelector('.toolbar-title');
+	await page.waitForTimeout(300);
+}
+
+function offsetDate(days: number): string {
+	const d = new Date();
+	d.setDate(d.getDate() + days);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const dd = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${dd}`;
+}
+
+const modal = (page: Page) => page.locator('.modal[role="dialog"]');
+
+async function clickCellAtDate(page: Page, dateIso: string, rowIndex = 0) {
+	const colIndex = await page.evaluate((date) => {
+		const headers = document.querySelectorAll('th.date-header[data-date]');
+		for (let i = 0; i < headers.length; i++) {
+			if (headers[i].getAttribute('data-date') === date) return i;
+		}
+		return -1;
+	}, dateIso);
+	if (colIndex === -1) throw new Error(`Date column ${dateIso} not found in grid`);
+
+	const cell = page.locator('tbody tr').nth(rowIndex).locator('td.grid-cell').nth(colIndex);
+	await cell.scrollIntoViewIfNeeded();
+	await cell.click();
+}
+
+async function createReservation(
+	page: Page,
+	opts: { name: string; rvType?: string; startDate: string; endDate: string; rowIndex?: number }
+) {
+	await clickCellAtDate(page, opts.startDate, opts.rowIndex ?? 0);
+	await expect(modal(page)).toBeVisible();
+
+	await modal(page).locator('[data-testid="guest-name-input"]').fill(opts.name);
+	await modal(page).locator('input[type="date"]').first().fill(opts.startDate);
+	await modal(page).locator('input[type="date"]').nth(1).fill(opts.endDate);
+	if (opts.rvType) {
+		await modal(page).locator('[data-testid="rv-type-input"]').fill(opts.rvType);
+	}
+
+	await modal(page).locator('button[type="submit"]').click();
+	await expect(modal(page)).not.toBeVisible();
+}
+
+test.describe('RV type in search', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('searching by RV type returns matching reservations', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(3);
+
+		await createReservation(page, { name: 'John Smith', rvType: 'Fifth Wheel', startDate: today, endDate, rowIndex: 0 });
+		await createReservation(page, { name: 'Jane Doe', rvType: 'Class A', startDate: today, endDate, rowIndex: 1 });
+
+		// Type "Fifth" in the search box
+		const searchInput = page.locator('input[aria-label="Search reservations"]');
+		await searchInput.fill('Fifth');
+
+		// Should see John Smith in the results
+		const dropdown = page.locator('.search-dropdown');
+		await expect(dropdown).toBeVisible();
+		await expect(dropdown.locator('.search-result-name')).toContainText(['John Smith']);
+	});
+
+	test('RV type displays in search dropdown results', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(3);
+
+		await createReservation(page, { name: 'Alice Johnson', rvType: 'Travel Trailer', startDate: today, endDate });
+
+		const searchInput = page.locator('input[aria-label="Search reservations"]');
+		await searchInput.fill('Alice');
+
+		const dropdown = page.locator('.search-dropdown');
+		await expect(dropdown).toBeVisible();
+
+		// RV type should appear in the result metadata
+		await expect(dropdown.locator('.search-result-rvtype')).toContainText(['Travel Trailer']);
+	});
+
+	test('search still works for name and location', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(3);
+
+		await createReservation(page, { name: 'Bob Williams', rvType: 'Class C', startDate: today, endDate });
+
+		// Search by name
+		const searchInput = page.locator('input[aria-label="Search reservations"]');
+		await searchInput.fill('Bob');
+		await expect(page.locator('.search-dropdown .search-result-name')).toContainText(['Bob Williams']);
+	});
+});

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -127,6 +127,47 @@ describe('filterReservations', () => {
 		expect(results[0].reservation.name).toBe('Bob Smith');
 	});
 
+	describe('RV type search', () => {
+		const rvTypeReservations: Reservation[] = [
+			makeReservation({ index: 1, name: 'Guest A', rvType: 'Fifth Wheel' }),
+			makeReservation({ index: 2, name: 'Guest B', rvType: 'Class A' }),
+			makeReservation({ index: 3, name: 'Guest C', rvType: 'Fifth Wheel' }),
+			makeReservation({ index: 4, name: 'Guest D', rvType: '' })
+		];
+
+		it('matches RV type case-insensitively', () => {
+			const results = filterReservations(rvTypeReservations, 'fifth');
+			const names = results.map((r) => r.reservation.name);
+			expect(names).toContain('Guest A');
+			expect(names).toContain('Guest C');
+			expect(names).not.toContain('Guest B');
+		});
+
+		it('ranks exact RV type match above partial', () => {
+			const results = filterReservations(rvTypeReservations, 'Class A');
+			expect(results[0].reservation.name).toBe('Guest B');
+			expect(results[0].score).toBe(0);
+		});
+
+		it('ranks startsWith above contains for RV type', () => {
+			const reservations = [
+				makeReservation({ index: 1, name: 'G1', rvType: 'Travel Trailer' }),
+				makeReservation({ index: 2, name: 'G2', rvType: 'Big Travel' })
+			];
+			const results = filterReservations(reservations, 'Travel');
+			expect(results[0].reservation.rvType).toBe('Travel Trailer');
+			expect(results[0].score).toBe(1);
+			expect(results[1].reservation.rvType).toBe('Big Travel');
+			expect(results[1].score).toBe(2);
+		});
+
+		it('does not match reservations with empty RV type', () => {
+			const results = filterReservations(rvTypeReservations, 'Fifth');
+			const names = results.map((r) => r.reservation.name);
+			expect(names).not.toContain('Guest D');
+		});
+	});
+
 	describe('phone number search', () => {
 		const phoneReservations: Reservation[] = [
 			makeReservation({ index: 1, name: 'Guest A', phoneNumber: '(555) 123-4567' }),


### PR DESCRIPTION
## Summary
- Search now matches against RV type in addition to guest name, parking location, and phone number
- RV type displays in toolbar search dropdown results between location and phone
- Added unit tests for RV type search matching (exact, startsWith, contains scoring)

## Test plan
- [ ] Search for an RV type (e.g. "Fifth Wheel") — matching reservations should appear
- [ ] Verify RV type shows in search dropdown results
- [ ] Verify existing name/location/phone search still works
- [ ] Unit tests pass: `npm run test:unit`