### PR TITLE
feat: date navigation — scroll to booked date + Go To Date input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.16.0",
+      "version": "1.18.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.18.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.16.0"
+version = "1.18.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.16.0",
+  "version": "1.18.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -320,17 +320,19 @@
     return `Saved ${ageHours}h ago (${formatTimestamp(lastSavedAt)})`;
   }
 
-  async function alignToToday(): Promise<void> {
+  async function scrollToDate(targetDateIso: string): Promise<void> {
     await tick();
     if (!gridScroller) return;
-    const todayIndex = diffDays(gridStartDate, todayIso);
-    // Align today's column to the left edge of the visible date area.
-    // The sticky first column occupies FIRST_COLUMN_WIDTH, so the visible date area
-    // starts at scrollLeft = todayIndex * DATE_COLUMN_WIDTH.
-    const targetScrollLeft = todayIndex * DATE_COLUMN_WIDTH;
+    const targetIndex = diffDays(gridStartDate, targetDateIso);
+    if (targetIndex < 0 || targetIndex >= TOTAL_DATE_COLUMNS) return;
+    const targetScrollLeft = targetIndex * DATE_COLUMN_WIDTH;
     const maxScrollLeft = Math.max(0, gridScroller.scrollWidth - gridScroller.clientWidth);
     gridScroller.scrollLeft = Math.min(Math.max(0, targetScrollLeft), maxScrollLeft);
     updateVisibleColumns();
+  }
+
+  async function alignToToday(): Promise<void> {
+    await scrollToDate(todayIso);
   }
 
   function scrollWeek(direction: number): void {
@@ -402,6 +404,7 @@
   }
 
   async function handleModalSave(event: CustomEvent<ReservationFormValues>): Promise<void> {
+    const isCreate = modalMode === 'create';
     const result = await saveReservationWithUndo(event.detail);
     if (!result.ok) {
       modalErrors = result.errors;
@@ -415,6 +418,10 @@
 
     closeModal();
     showToast('Reservation saved');
+
+    if (isCreate) {
+      await scrollToDate(event.detail.startDate);
+    }
   }
 
   async function handleModalDelete(event: CustomEvent<{ index: number }>): Promise<void> {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -557,6 +557,7 @@
         class="goto-date-input"
         bind:value={goToDateValue}
         on:change={handleGoToDate}
+        on:input={handleGoToDate}
         aria-label="Go to date"
         title="Jump to a specific date"
         data-testid="goto-date-input"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -94,6 +94,9 @@
     status: 'reserved'
   };
 
+  // Go To Date state
+  let goToDateValue = '';
+
   // Search state
   let searchQuery = '';
   let searchOpen = false;
@@ -339,6 +342,11 @@
     gridScroller?.scrollBy({ left: DATE_COLUMN_WIDTH * 7 * direction, behavior: 'smooth' });
   }
 
+  async function handleGoToDate(): Promise<void> {
+    if (!goToDateValue) return;
+    await scrollToDate(goToDateValue);
+  }
+
   function openNewReservationModal(): void {
     const firstLocation = $rvReservationStore.parkingLocations[0] ?? '';
     modalMode = 'create';
@@ -544,6 +552,15 @@
       <button type="button" on:click={() => scrollWeek(-1)} aria-label="Previous week">&#8592;</button>
       <button type="button" class="primary" data-testid="today-button" on:click={alignToToday}>Today</button>
       <button type="button" on:click={() => scrollWeek(1)} aria-label="Next week">&#8594;</button>
+      <input
+        type="date"
+        class="goto-date-input"
+        bind:value={goToDateValue}
+        on:change={handleGoToDate}
+        aria-label="Go to date"
+        title="Jump to a specific date"
+        data-testid="goto-date-input"
+      />
       <button
         type="button"
         class="compact-toggle-btn"
@@ -868,6 +885,25 @@
   .summary-sep {
     color: #a0b4cc;
     font-weight: 300;
+  }
+
+  .goto-date-input {
+    border-radius: 8px;
+    border: 1px solid #c3cddd;
+    background: #f4f7fc;
+    color: #223349;
+    padding: 0.3rem 0.5rem;
+    font-weight: 600;
+    font-size: 0.8rem;
+    min-height: 36px;
+    width: 9.5rem;
+    font-family: inherit;
+  }
+
+  .goto-date-input:focus {
+    background: white;
+    border-color: #0a63e0;
+    outline: none;
   }
 
   .toolbar-nav button {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -326,8 +326,8 @@
   async function scrollToDate(targetDateIso: string): Promise<void> {
     await tick();
     if (!gridScroller) return;
-    const targetIndex = diffDays(gridStartDate, targetDateIso);
-    if (targetIndex < 0 || targetIndex >= TOTAL_DATE_COLUMNS) return;
+    const rawIndex = diffDays(gridStartDate, targetDateIso);
+    const targetIndex = Math.min(Math.max(0, rawIndex), TOTAL_DATE_COLUMNS - 1);
     const targetScrollLeft = targetIndex * DATE_COLUMN_WIDTH;
     const maxScrollLeft = Math.max(0, gridScroller.scrollWidth - gridScroller.clientWidth);
     gridScroller.scrollLeft = Math.min(Math.max(0, targetScrollLeft), maxScrollLeft);

--- a/tests/e2e/date-navigation.spec.ts
+++ b/tests/e2e/date-navigation.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function resetApp(page: Page) {
+	await page.goto('/');
+	await page.evaluate(() => window.localStorage.clear());
+	await page.reload();
+	await page.waitForSelector('.toolbar-title');
+	await page.waitForTimeout(300);
+}
+
+function offsetDate(days: number): string {
+	const d = new Date();
+	d.setDate(d.getDate() + days);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const dd = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${dd}`;
+}
+
+const modal = (page: Page) => page.locator('.modal[role="dialog"]');
+
+test.describe('Date navigation', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('grid scrolls to booked date after creating a reservation', async ({ page }) => {
+		// Click "+ New Reservation" button
+		await page.click('[data-testid="new-reservation-btn"]');
+		await expect(modal(page)).toBeVisible();
+
+		// Book 14 days in the future (far enough that grid needs to scroll)
+		const futureDate = offsetDate(14);
+		const endDate = offsetDate(17);
+
+		await modal(page).locator('[data-testid="guest-name-input"]').fill('Future Guest');
+		await modal(page).locator('input[type="date"]').first().fill(futureDate);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+
+		// Wait for scroll to settle
+		await page.waitForTimeout(500);
+
+		// The future date column should now be visible in the viewport
+		const futureDateHeader = page.locator(`th.date-header[data-date="${futureDate}"]`);
+		await expect(futureDateHeader).toBeVisible();
+	});
+
+	test('grid does not scroll after editing an existing reservation', async ({ page }) => {
+		// First scroll to today
+		await page.click('[data-testid="today-button"]');
+		await page.waitForTimeout(300);
+
+		// Get current scroll position
+		const scrollBefore = await page.evaluate(() => {
+			const scroller = document.querySelector('.sheet-scroll');
+			return scroller?.scrollLeft ?? 0;
+		});
+
+		// Create a reservation for today
+		const today = offsetDate(0);
+		const endDate = offsetDate(3);
+		await page.click('[data-testid="new-reservation-btn"]');
+		await expect(modal(page)).toBeVisible();
+		await modal(page).locator('[data-testid="guest-name-input"]').fill('Test Guest');
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+		await page.waitForTimeout(500);
+
+		// Scroll back to today
+		await page.click('[data-testid="today-button"]');
+		await page.waitForTimeout(300);
+
+		// Now open the reservation in edit mode
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.scrollIntoViewIfNeeded();
+		await occupied.click();
+		await expect(modal(page)).toBeVisible();
+
+		// Get scroll position before edit save
+		const scrollBeforeEdit = await page.evaluate(() => {
+			const scroller = document.querySelector('.sheet-scroll');
+			return scroller?.scrollLeft ?? 0;
+		});
+
+		// Save the edit (no changes)
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+		await page.waitForTimeout(500);
+
+		// Scroll should not have changed (edits don't trigger scroll)
+		const scrollAfterEdit = await page.evaluate(() => {
+			const scroller = document.querySelector('.sheet-scroll');
+			return scroller?.scrollLeft ?? 0;
+		});
+		expect(scrollAfterEdit).toBe(scrollBeforeEdit);
+	});
+
+	test('Go To Date input is visible in toolbar', async ({ page }) => {
+		const goToInput = page.locator('[data-testid="goto-date-input"]');
+		await expect(goToInput).toBeVisible();
+		await expect(goToInput).toHaveAttribute('type', 'date');
+	});
+
+	test('Today button still works', async ({ page }) => {
+		const today = offsetDate(0);
+
+		// Now click Today
+		await page.click('[data-testid="today-button"]');
+		await page.waitForTimeout(500);
+
+		// Today's column should be visible
+		const todayHeader = page.locator('th.date-header.today');
+		await expect(todayHeader).toBeVisible();
+	});
+});


### PR DESCRIPTION
## Summary
- Extract `scrollToDate()` from `alignToToday()` for reusable date navigation
- After saving a new reservation, the grid scrolls to the reservation's start date so the user can visually confirm it was booked
- Add a native date input in the toolbar that lets users jump to any date in the grid
- "Book Again" flow also benefits — after saving the new reservation, grid scrolls to the booked dates

## Test plan
- [ ] Create a reservation 2+ weeks in the future — grid should scroll to show that date after save
- [ ] Edit an existing reservation — grid should NOT scroll after save (only new reservations)
- [ ] Use the date picker in the toolbar to jump to a specific date
- [ ] Click "Today" button — should still work as before
- [ ] Week arrows should still scroll normally