### PR TITLE
feat: add custom colors per RV site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.16.0",
+      "version": "1.19.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.19.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.16.0"
+version = "1.19.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.16.0",
+  "version": "1.19.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/application/use-cases/admin/admin-settings-use-cases.ts
+++ b/src/lib/application/use-cases/admin/admin-settings-use-cases.ts
@@ -27,6 +27,20 @@ export interface AdminSettingsUseCases {
 		enabled: boolean,
 		currentSettings: SiteSettings
 	): { ok: true; settings: SiteSettings };
+	setSiteColor(
+		locationName: string,
+		color: string | null,
+		currentSettings: SiteSettings
+	): { ok: true; settings: SiteSettings };
+	renameSiteColor(
+		oldName: string,
+		newName: string,
+		currentSettings: SiteSettings
+	): { ok: true; settings: SiteSettings };
+	removeSiteColor(
+		locationName: string,
+		currentSettings: SiteSettings
+	): { ok: true; settings: SiteSettings };
 }
 
 export function createAdminSettingsUseCases(
@@ -105,6 +119,48 @@ export function createAdminSettingsUseCases(
 			currentSettings: SiteSettings
 		): { ok: true; settings: SiteSettings } {
 			const saved = repo.save({ ...currentSettings, betaUpdates: enabled });
+			return { ok: true, settings: saved };
+		},
+
+		setSiteColor(
+			locationName: string,
+			color: string | null,
+			currentSettings: SiteSettings
+		): { ok: true; settings: SiteSettings } {
+			const colors = { ...(currentSettings.siteColors ?? {}) };
+			if (color) {
+				colors[locationName] = color;
+			} else {
+				delete colors[locationName];
+			}
+			const siteColors = Object.keys(colors).length > 0 ? colors : undefined;
+			const saved = repo.save({ ...currentSettings, siteColors });
+			return { ok: true, settings: saved };
+		},
+
+		renameSiteColor(
+			oldName: string,
+			newName: string,
+			currentSettings: SiteSettings
+		): { ok: true; settings: SiteSettings } {
+			const colors = { ...(currentSettings.siteColors ?? {}) };
+			if (oldName in colors) {
+				colors[newName] = colors[oldName];
+				delete colors[oldName];
+			}
+			const siteColors = Object.keys(colors).length > 0 ? colors : undefined;
+			const saved = repo.save({ ...currentSettings, siteColors });
+			return { ok: true, settings: saved };
+		},
+
+		removeSiteColor(
+			locationName: string,
+			currentSettings: SiteSettings
+		): { ok: true; settings: SiteSettings } {
+			const colors = { ...(currentSettings.siteColors ?? {}) };
+			delete colors[locationName];
+			const siteColors = Object.keys(colors).length > 0 ? colors : undefined;
+			const saved = repo.save({ ...currentSettings, siteColors });
 			return { ok: true, settings: saved };
 		}
 	};

--- a/src/lib/components/ParkingLocationsPanel.svelte
+++ b/src/lib/components/ParkingLocationsPanel.svelte
@@ -3,15 +3,41 @@
 
   export let locations: string[] = [];
   export let reservationCounts: Record<string, number> = {};
+  export let siteColors: Record<string, string> = {};
   export let errorMessage = '';
+
+  const PRESET_COLORS = [
+    { hex: '#4477AA', label: 'Blue' },
+    { hex: '#EE6677', label: 'Rose' },
+    { hex: '#228833', label: 'Green' },
+    { hex: '#CCBB44', label: 'Yellow' },
+    { hex: '#66CCEE', label: 'Cyan' },
+    { hex: '#AA3377', label: 'Purple' },
+    { hex: '#EE8866', label: 'Orange' },
+    { hex: '#BBBBBB', label: 'Gray' },
+    { hex: '#44AA99', label: 'Teal' },
+    { hex: '#DDCC77', label: 'Sand' }
+  ];
 
   const dispatch = createEventDispatcher<{
     add: { name: string };
     rename: { oldName: string; newName: string };
     remove: { name: string };
     reorder: { orderedNames: string[] };
+    colorchange: { name: string; color: string | null };
     clearerror: void;
   }>();
+
+  let colorPickerOpen: string | null = null;
+
+  function toggleColorPicker(location: string): void {
+    colorPickerOpen = colorPickerOpen === location ? null : location;
+  }
+
+  function selectColor(location: string, color: string | null): void {
+    dispatch('colorchange', { name: location, color });
+    colorPickerOpen = null;
+  }
 
   let newLocationName = '';
   let openMenu: string | null = null;
@@ -73,6 +99,9 @@
     const target = event.target as HTMLElement;
     if (openMenu && !target.closest('.kebab-wrapper')) {
       openMenu = null;
+    }
+    if (colorPickerOpen && !target.closest('.color-picker-wrapper')) {
+      colorPickerOpen = null;
     }
   }
 
@@ -197,6 +226,41 @@
               on:pointerup={handlePointerUp}
             >&#x2630;</span>
             <span class="location-name">{location}</span>
+            <div class="color-picker-wrapper">
+              <button
+                type="button"
+                class="color-swatch-btn"
+                style={siteColors[location] ? `background-color: ${siteColors[location]}` : ''}
+                class:no-color={!siteColors[location]}
+                aria-label={`Set color for ${location}`}
+                title="Set row color"
+                on:click|stopPropagation={() => toggleColorPicker(location)}
+              >{siteColors[location] ? '' : '+'}</button>
+              {#if colorPickerOpen === location}
+                <div class="color-picker-dropdown" role="listbox" aria-label="Pick a color">
+                  {#each PRESET_COLORS as preset}
+                    <button
+                      type="button"
+                      class="color-option"
+                      class:selected={siteColors[location] === preset.hex}
+                      style="background-color: {preset.hex}"
+                      aria-label={preset.label}
+                      title={preset.label}
+                      on:click|stopPropagation={() => selectColor(location, preset.hex)}
+                    ></button>
+                  {/each}
+                  {#if siteColors[location]}
+                    <button
+                      type="button"
+                      class="color-option clear-color"
+                      aria-label="Clear color"
+                      title="Clear color"
+                      on:click|stopPropagation={() => selectColor(location, null)}
+                    >&times;</button>
+                  {/if}
+                </div>
+              {/if}
+            </div>
             <span class="count">{reservationCounts[location] ?? 0} reservations</span>
             <div class="kebab-wrapper">
               <button
@@ -341,7 +405,7 @@
 
   .location-row {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    grid-template-columns: auto minmax(0, 1fr) auto auto auto;
     gap: 0.4rem;
     align-items: center;
   }
@@ -450,9 +514,90 @@
     background: #fff0f0;
   }
 
+  /* Color picker */
+  .color-picker-wrapper {
+    position: relative;
+  }
+
+  .color-swatch-btn {
+    width: 24px;
+    height: 24px;
+    min-width: 24px;
+    border-radius: 6px;
+    border: 2px solid #d0d8e4;
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.8rem;
+    line-height: 1;
+    color: #8899b0;
+    display: grid;
+    place-items: center;
+    min-height: auto;
+  }
+
+  .color-swatch-btn:not(.no-color) {
+    border-color: rgba(0, 0, 0, 0.2);
+  }
+
+  .color-swatch-btn:hover {
+    border-color: #0a63e0;
+  }
+
+  .color-picker-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: white;
+    border: 1px solid #d6deea;
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(10, 24, 47, 0.14);
+    padding: 0.4rem;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 0.3rem;
+    z-index: 20;
+    min-width: 0;
+  }
+
+  .color-option {
+    width: 28px;
+    height: 28px;
+    min-width: 28px;
+    min-height: 28px;
+    border-radius: 6px;
+    border: 2px solid transparent;
+    cursor: pointer;
+    padding: 0;
+    transition: border-color 0.1s;
+  }
+
+  .color-option:hover {
+    border-color: #1b304a;
+  }
+
+  .color-option.selected {
+    border-color: #0a63e0;
+    box-shadow: 0 0 0 2px rgba(10, 99, 224, 0.3);
+  }
+
+  .color-option.clear-color {
+    background: white;
+    border: 2px dashed #c8d1de;
+    color: #8899b0;
+    font-size: 1rem;
+    display: grid;
+    place-items: center;
+  }
+
+  .color-option.clear-color:hover {
+    border-color: #d42a2a;
+    color: #d42a2a;
+  }
+
   @media (max-width: 900px) {
     .location-row {
-      grid-template-columns: auto minmax(0, 1fr) auto auto;
+      grid-template-columns: auto minmax(0, 1fr) auto auto auto;
     }
 
     .count {

--- a/src/lib/components/ParkingLocationsPanel.svelte
+++ b/src/lib/components/ParkingLocationsPanel.svelte
@@ -31,6 +31,7 @@
   let colorPickerOpen: string | null = null;
 
   function toggleColorPicker(location: string): void {
+    openMenu = null;
     colorPickerOpen = colorPickerOpen === location ? null : location;
   }
 
@@ -56,6 +57,7 @@
   }
 
   function toggleMenu(location: string): void {
+    colorPickerOpen = null;
     if (openMenu === location) {
       openMenu = null;
     } else {
@@ -237,7 +239,7 @@
                 on:click|stopPropagation={() => toggleColorPicker(location)}
               >{siteColors[location] ? '' : '+'}</button>
               {#if colorPickerOpen === location}
-                <div class="color-picker-dropdown" role="listbox" aria-label="Pick a color">
+                <div class="color-picker-dropdown" role="group" aria-label="Pick a color">
                   {#each PRESET_COLORS as preset}
                     <button
                       type="button"

--- a/src/lib/infrastructure/storage/sqlite/site-settings-repository.ts
+++ b/src/lib/infrastructure/storage/sqlite/site-settings-repository.ts
@@ -22,7 +22,11 @@ function sanitize(settings: SiteSettings): SiteSettings {
 	const siteName =
 		settings.siteName?.trim().slice(0, 80) || DEFAULT_SITE_NAME;
 	const autoBackup = settings.autoBackup ?? defaultAutoBackup();
-	return { siteName, compactView: settings.compactView, autoBackup, betaUpdates: settings.betaUpdates };
+	const result: SiteSettings = { siteName, compactView: settings.compactView, autoBackup, betaUpdates: settings.betaUpdates };
+	if (settings.siteColors && Object.keys(settings.siteColors).length > 0) {
+		result.siteColors = settings.siteColors;
+	}
+	return result;
 }
 
 async function loadFromDb(db: Database): Promise<SiteSettings> {
@@ -34,6 +38,17 @@ async function loadFromDb(db: Database): Promise<SiteSettings> {
 		? (rawInterval as AutoBackupIntervalMinutes)
 		: 0;
 
+	let siteColors: Record<string, string> | undefined;
+	const rawColors = map.get('site_colors');
+	if (rawColors) {
+		try {
+			const parsed = JSON.parse(rawColors);
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				siteColors = parsed as Record<string, string>;
+			}
+		} catch { /* ignore invalid JSON */ }
+	}
+
 	return sanitize({
 		siteName: map.get('site_name') ?? DEFAULT_SITE_NAME,
 		compactView: map.get('compact_view') === '1',
@@ -42,7 +57,8 @@ async function loadFromDb(db: Database): Promise<SiteSettings> {
 			intervalMinutes,
 			directoryPath: map.get('auto_backup_directory') ?? null,
 			lastBackupAt: map.get('auto_backup_last_at') ?? null
-		}
+		},
+		siteColors
 	});
 }
 
@@ -80,6 +96,15 @@ async function saveToDb(db: Database, settings: SiteSettings): Promise<void> {
 		]);
 	} else {
 		await db.execute('DELETE FROM admin_settings WHERE key = ?', ['auto_backup_last_at']);
+	}
+
+	if (settings.siteColors && Object.keys(settings.siteColors).length > 0) {
+		await db.execute('INSERT OR REPLACE INTO admin_settings (key, value) VALUES (?, ?)', [
+			'site_colors',
+			JSON.stringify(settings.siteColors)
+		]);
+	} else {
+		await db.execute('DELETE FROM admin_settings WHERE key = ?', ['site_colors']);
 	}
 }
 

--- a/src/lib/infrastructure/storage/sqlite/site-settings-repository.ts
+++ b/src/lib/infrastructure/storage/sqlite/site-settings-repository.ts
@@ -42,9 +42,18 @@ async function loadFromDb(db: Database): Promise<SiteSettings> {
 	const rawColors = map.get('site_colors');
 	if (rawColors) {
 		try {
+			const hexPattern = /^#[0-9a-f]{6}$/i;
 			const parsed = JSON.parse(rawColors);
 			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-				siteColors = parsed as Record<string, string>;
+				const cleaned: Record<string, string> = {};
+				for (const [k, v] of Object.entries(parsed)) {
+					if (typeof k === 'string' && k.trim() && typeof v === 'string' && hexPattern.test(v.trim())) {
+						cleaned[k.trim()] = v.trim();
+					}
+				}
+				if (Object.keys(cleaned).length > 0) {
+					siteColors = cleaned;
+				}
 			}
 		} catch { /* ignore invalid JSON */ }
 	}

--- a/src/lib/site-settings.ts
+++ b/src/lib/site-settings.ts
@@ -89,6 +89,27 @@ function createSiteSettingsStore() {
 		return persistSettings(result.settings);
 	}
 
+	async function setSiteColor(locationName: string, color: string | null): Promise<SiteSettingsMutationResult> {
+		const { adminSettingsUseCases } = getAppServices();
+		const current = get(internal);
+		const result = adminSettingsUseCases.setSiteColor(locationName, color, current);
+		return persistSettings(result.settings);
+	}
+
+	async function renameSiteColor(oldName: string, newName: string): Promise<SiteSettingsMutationResult> {
+		const { adminSettingsUseCases } = getAppServices();
+		const current = get(internal);
+		const result = adminSettingsUseCases.renameSiteColor(oldName, newName, current);
+		return persistSettings(result.settings);
+	}
+
+	async function removeSiteColor(locationName: string): Promise<SiteSettingsMutationResult> {
+		const { adminSettingsUseCases } = getAppServices();
+		const current = get(internal);
+		const result = adminSettingsUseCases.removeSiteColor(locationName, current);
+		return persistSettings(result.settings);
+	}
+
 	return {
 		subscribe: internal.subscribe,
 		hydrate,
@@ -97,7 +118,10 @@ function createSiteSettingsStore() {
 		setAutoBackupInterval,
 		setAutoBackupDirectory,
 		recordAutoBackup,
-		setBetaUpdates
+		setBetaUpdates,
+		setSiteColor,
+		renameSiteColor,
+		removeSiteColor
 	};
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -189,11 +189,14 @@ function sanitizeSiteSettings(value: unknown): SiteSettings {
   }
 
   if (raw.siteColors && typeof raw.siteColors === 'object' && !Array.isArray(raw.siteColors)) {
+    const hexPattern = /^#[0-9a-f]{6}$/i;
     const sc = raw.siteColors as Record<string, unknown>;
     const cleaned: Record<string, string> = {};
     for (const [key, val] of Object.entries(sc)) {
-      if (typeof val === 'string' && val.trim()) {
-        cleaned[key] = val.trim();
+      const trimmedKey = typeof key === 'string' ? key.trim() : '';
+      const trimmedVal = typeof val === 'string' ? val.trim() : '';
+      if (trimmedKey && trimmedVal && hexPattern.test(trimmedVal)) {
+        cleaned[trimmedKey] = trimmedVal;
       }
     }
     if (Object.keys(cleaned).length > 0) {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -188,6 +188,19 @@ function sanitizeSiteSettings(value: unknown): SiteSettings {
     };
   }
 
+  if (raw.siteColors && typeof raw.siteColors === 'object' && !Array.isArray(raw.siteColors)) {
+    const sc = raw.siteColors as Record<string, unknown>;
+    const cleaned: Record<string, string> = {};
+    for (const [key, val] of Object.entries(sc)) {
+      if (typeof val === 'string' && val.trim()) {
+        cleaned[key] = val.trim();
+      }
+    }
+    if (Object.keys(cleaned).length > 0) {
+      result.siteColors = cleaned;
+    }
+  }
+
   return result;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,7 @@ export interface SiteSettings {
   compactView?: boolean;
   autoBackup?: AutoBackupConfig;
   betaUpdates?: boolean;
+  siteColors?: Record<string, string>;
 }
 
 export interface ActionResult {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -723,8 +723,13 @@
 
           <tbody>
             {#each $rvReservationStore.parkingLocations as location}
+              {@const siteColor = $siteSettingsStore.siteColors?.[location]}
               <tr>
-                <th class="sticky-col location-cell" scope="row">{location}</th>
+                <th
+                  class="sticky-col location-cell"
+                  scope="row"
+                  style={siteColor ? `background-color: ${siteColor}18; border-left: 3px solid ${siteColor}` : ''}
+                >{location}</th>
                 {#if leftSpacerWidth > 0}
                   <td class="spacer-cell" aria-hidden="true"></td>
                 {/if}
@@ -733,9 +738,10 @@
                   {@const reservation = occupancyMap.get(cellId)}
                   {@const isDragSource = dragState?.started && reservation?.index === dragState.reservation.index}
                   {@const isDragPreview = dragPreviewCells.has(cellId)}
+                  {@const emptyCellStyle = !reservation && siteColor ? `background-color: ${siteColor}0D` : ''}
                   <td
                     class={`grid-cell ${reservation ? 'occupied' : 'empty'} ${dateIso === todayIso ? 'today' : ''} ${isDragSource ? 'drag-source' : ''} ${isDragPreview ? (dragHasOverlap ? 'drag-preview-error' : 'drag-preview') : ''}`}
-                    style={reservation && !isDragSource ? getStatusCellStyle(reservation.status) : ''}
+                    style={reservation && !isDragSource ? getStatusCellStyle(reservation.status) : emptyCellStyle}
                     on:click={(e) => openModalForCell(location, dateIso, e)}
                     on:pointerdown={(e) => handleCellPointerDown(location, dateIso, e)}
                     title={getReservationCellTitle(location, dateIso, reservation)}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -142,7 +142,10 @@
     const result = await rvReservationStore.renameParkingLocation(event.detail.oldName, event.detail.newName);
     applyLocationMutation(result);
     if (result.ok) {
-      await siteSettingsStore.renameSiteColor(event.detail.oldName, event.detail.newName);
+      const colorResult = await siteSettingsStore.renameSiteColor(event.detail.oldName, event.detail.newName);
+      if (!colorResult.ok) {
+        locationPanelError = colorResult.errors?.[0] ?? 'Location renamed, but site color could not be updated.';
+      }
     }
   }
 
@@ -150,7 +153,10 @@
     const result = await rvReservationStore.deleteParkingLocation(event.detail.name);
     applyLocationMutation(result);
     if (result.ok) {
-      await siteSettingsStore.removeSiteColor(event.detail.name);
+      const colorResult = await siteSettingsStore.removeSiteColor(event.detail.name);
+      if (!colorResult.ok) {
+        console.error('Failed to remove site color:', colorResult.errors);
+      }
     }
   }
 
@@ -159,7 +165,10 @@
   }
 
   async function handleColorChange(event: CustomEvent<{ name: string; color: string | null }>): Promise<void> {
-    await siteSettingsStore.setSiteColor(event.detail.name, event.detail.color);
+    const result = await siteSettingsStore.setSiteColor(event.detail.name, event.detail.color);
+    if (!result.ok) {
+      locationPanelError = result.errors?.[0] ?? 'Failed to save site color.';
+    }
   }
 
   const JSON_FILTERS = [{ name: 'JSON', extensions: ['json'] }];

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -139,15 +139,27 @@
   }
 
   async function handleRenameLocation(event: CustomEvent<{ oldName: string; newName: string }>): Promise<void> {
-    applyLocationMutation(await rvReservationStore.renameParkingLocation(event.detail.oldName, event.detail.newName));
+    const result = await rvReservationStore.renameParkingLocation(event.detail.oldName, event.detail.newName);
+    applyLocationMutation(result);
+    if (result.ok) {
+      await siteSettingsStore.renameSiteColor(event.detail.oldName, event.detail.newName);
+    }
   }
 
   async function handleDeleteLocation(event: CustomEvent<{ name: string }>): Promise<void> {
-    applyLocationMutation(await rvReservationStore.deleteParkingLocation(event.detail.name));
+    const result = await rvReservationStore.deleteParkingLocation(event.detail.name);
+    applyLocationMutation(result);
+    if (result.ok) {
+      await siteSettingsStore.removeSiteColor(event.detail.name);
+    }
   }
 
   async function handleReorderLocations(event: CustomEvent<{ orderedNames: string[] }>): Promise<void> {
     applyLocationMutation(await rvReservationStore.reorderParkingLocations(event.detail.orderedNames));
+  }
+
+  async function handleColorChange(event: CustomEvent<{ name: string; color: string | null }>): Promise<void> {
+    await siteSettingsStore.setSiteColor(event.detail.name, event.detail.color);
   }
 
   const JSON_FILTERS = [{ name: 'JSON', extensions: ['json'] }];
@@ -544,11 +556,13 @@
     <ParkingLocationsPanel
       locations={$rvReservationStore.parkingLocations}
       reservationCounts={reservationCountsByLocation}
+      siteColors={$siteSettingsStore.siteColors ?? {}}
       errorMessage={locationPanelError}
       on:add={handleAddLocation}
       on:rename={handleRenameLocation}
       on:remove={handleDeleteLocation}
       on:reorder={handleReorderLocations}
+      on:colorchange={handleColorChange}
       on:clearerror={() => (locationPanelError = '')}
     />
   </div>

--- a/tests/e2e/site-colors.spec.ts
+++ b/tests/e2e/site-colors.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function resetApp(page: Page) {
+	await page.goto('/');
+	await page.evaluate(() => window.localStorage.clear());
+	await page.reload();
+	await page.waitForSelector('.toolbar-title');
+	await page.waitForTimeout(300);
+}
+
+test.describe('Site colors', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('color swatch buttons appear in site management panel', async ({ page }) => {
+		await page.click('[data-testid="settings-link"]');
+		await page.waitForURL(/\/admin$/);
+		await page.waitForSelector('[data-testid="sites-management"]');
+		await page.waitForTimeout(500);
+
+		// Each site row should have a color swatch button
+		const swatches = page.locator('[data-testid="sites-management"] .color-swatch-btn');
+		const count = await swatches.count();
+		expect(count).toBeGreaterThan(0);
+	});
+
+	test('clicking color swatch opens preset picker', async ({ page }) => {
+		await page.click('[data-testid="settings-link"]');
+		await page.waitForURL(/\/admin$/);
+		await page.waitForSelector('[data-testid="sites-management"]');
+		await page.waitForTimeout(500);
+
+		// Click the first site's color swatch
+		const firstSwatch = page.locator('.color-swatch-btn').first();
+		await firstSwatch.click();
+
+		// Color picker dropdown should appear
+		const picker = page.locator('.color-picker-dropdown');
+		await expect(picker).toBeVisible();
+
+		// Should have 10 preset color options
+		const options = picker.locator('.color-option:not(.clear-color)');
+		await expect(options).toHaveCount(10);
+	});
+
+	test('selecting a color applies it to the site row in grid', async ({ page }) => {
+		await page.click('[data-testid="settings-link"]');
+		await page.waitForURL(/\/admin$/);
+		await page.waitForSelector('[data-testid="sites-management"]');
+		await page.waitForTimeout(500);
+
+		// Click the first site's color swatch and pick a color
+		await page.locator('.color-swatch-btn').first().click();
+		const picker = page.locator('.color-picker-dropdown');
+		await expect(picker).toBeVisible();
+
+		// Click the first preset color
+		await picker.locator('.color-option').first().click();
+		await expect(picker).toBeHidden();
+
+		// The swatch should now have a background color (no longer has .no-color class)
+		const swatch = page.locator('.color-swatch-btn').first();
+		const hasNoColor = await swatch.evaluate((el) => el.classList.contains('no-color'));
+		expect(hasNoColor).toBe(false);
+
+		// Navigate back to grid and verify the first site row has a colored header
+		await page.click('[data-testid="back-to-schedule"]');
+		await page.waitForSelector('.toolbar-title');
+		await page.waitForTimeout(300);
+
+		const firstLocationCell = page.locator('.location-cell').first();
+		const bgColor = await firstLocationCell.evaluate((el) => el.style.backgroundColor);
+		expect(bgColor).not.toBe('');
+	});
+
+	test('clearing a color removes the tint', async ({ page }) => {
+		await page.click('[data-testid="settings-link"]');
+		await page.waitForURL(/\/admin$/);
+
+		// Set a color first
+		await page.locator('.color-swatch-btn').first().click();
+		await page.locator('.color-picker-dropdown .color-option').first().click();
+		await page.waitForTimeout(200);
+
+		// Re-open picker and clear the color
+		await page.locator('.color-swatch-btn').first().click();
+		const clearBtn = page.locator('.color-option.clear-color');
+		await expect(clearBtn).toBeVisible();
+		await clearBtn.click();
+
+		// Swatch should have .no-color class again
+		const swatch = page.locator('.color-swatch-btn').first();
+		const hasNoColor = await swatch.evaluate((el) => el.classList.contains('no-color'));
+		expect(hasNoColor).toBe(true);
+	});
+
+	test('site color persists across page reload', async ({ page }) => {
+		await page.click('[data-testid="settings-link"]');
+		await page.waitForURL(/\/admin$/);
+
+		// Set a color
+		await page.locator('.color-swatch-btn').first().click();
+		await page.locator('.color-picker-dropdown .color-option').first().click();
+		await page.waitForTimeout(300);
+
+		// Get the swatch's background color
+		const colorBefore = await page.locator('.color-swatch-btn').first().evaluate(
+			(el) => el.style.backgroundColor
+		);
+
+		// Reload
+		await page.reload();
+		await page.waitForSelector('[data-testid="sites-management"]');
+		await page.waitForTimeout(300);
+
+		// Color should persist
+		const colorAfter = await page.locator('.color-swatch-btn').first().evaluate(
+			(el) => el.style.backgroundColor
+		);
+		expect(colorAfter).toBe(colorBefore);
+	});
+});

--- a/tests/unit/admin-use-cases.test.ts
+++ b/tests/unit/admin-use-cases.test.ts
@@ -57,4 +57,51 @@ describe('AdminSettingsUseCases', () => {
 			expect(result.settings?.siteName).toBe('Padded Name');
 		}
 	});
+
+	describe('site colors', () => {
+		it('setSiteColor adds a color to settings', () => {
+			const repo = createFakeRepo();
+			const useCases = createAdminSettingsUseCases(repo);
+			const current = repo.load();
+			const result = useCases.setSiteColor('A-01', '#4477AA', current);
+			expect(result.ok).toBe(true);
+			expect(result.settings.siteColors).toEqual({ 'A-01': '#4477AA' });
+		});
+
+		it('setSiteColor with null removes the color', () => {
+			const repo = createFakeRepo();
+			const useCases = createAdminSettingsUseCases(repo);
+			const withColor = useCases.setSiteColor('A-01', '#4477AA', repo.load()).settings;
+			const result = useCases.setSiteColor('A-01', null, withColor);
+			expect(result.ok).toBe(true);
+			expect(result.settings.siteColors).toBeUndefined();
+		});
+
+		it('renameSiteColor transfers color to new key', () => {
+			const repo = createFakeRepo();
+			const useCases = createAdminSettingsUseCases(repo);
+			const withColor = useCases.setSiteColor('A-01', '#EE6677', repo.load()).settings;
+			const result = useCases.renameSiteColor('A-01', 'B-01', withColor);
+			expect(result.ok).toBe(true);
+			expect(result.settings.siteColors).toEqual({ 'B-01': '#EE6677' });
+		});
+
+		it('renameSiteColor is a no-op when site has no color', () => {
+			const repo = createFakeRepo();
+			const useCases = createAdminSettingsUseCases(repo);
+			const current = repo.load();
+			const result = useCases.renameSiteColor('A-01', 'B-01', current);
+			expect(result.ok).toBe(true);
+			expect(result.settings.siteColors).toBeUndefined();
+		});
+
+		it('removeSiteColor deletes the entry', () => {
+			const repo = createFakeRepo();
+			const useCases = createAdminSettingsUseCases(repo);
+			const withColor = useCases.setSiteColor('A-01', '#228833', repo.load()).settings;
+			const result = useCases.removeSiteColor('A-01', withColor);
+			expect(result.ok).toBe(true);
+			expect(result.settings.siteColors).toBeUndefined();
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Add `siteColors` map to `SiteSettings` for per-site color configuration
- Curated preset palette of 10 color-blind accessible colors (Wong palette based)
- Color picker UI in ParkingLocationsPanel on the settings page
- Subtle row tinting in the grid: location header gets colored left border + light tint, empty cells get very subtle tint
- Occupied cells keep their status colors (status takes priority)
- Colors automatically sync when sites are renamed or deleted
- Persisted in both localStorage and SQLite backends

## Architecture
- `SiteSettings.siteColors?: Record<string, string>` — no migration of `parkingLocations: string[]` needed
- Use cases: `setSiteColor`, `renameSiteColor`, `removeSiteColor`
- Grid applies color via inline styles using hex + opacity suffix (`#RRGGBB18` for headers, `#RRGGBB0D` for empty cells)

## Test plan
- [ ] Go to Settings, click color swatch on a site, select a color
- [ ] Verify grid shows the colored row (header + empty cells tinted)
- [ ] Select a different color — verify it updates
- [ ] Clear the color — verify row returns to default
- [ ] Rename a site — verify the color follows it
- [ ] Delete a site — verify no orphaned color entry
- [ ] Verify occupied cells still show status colors correctly
- [ ] Build passes, unit tests pass