### PR TITLE
feat: add no-show reservation status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.16.0",
+      "version": "1.20.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.16.0",
+  "version": "1.20.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.16.0"
+version = "1.20.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.16.0",
+  "version": "1.20.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/domain/reservations/status.ts
+++ b/src/lib/domain/reservations/status.ts
@@ -12,7 +12,8 @@ export const STATUS_COLORS: Record<ReservationStatus, string> = {
 	'group-two': '#F0E442',
 	'special': '#CC79A7',
 	'alert': '#D55E00',
-	'maintenance': '#7B8A99'
+	'maintenance': '#7B8A99',
+	'no-show': '#882255'
 };
 
 export const STATUS_BACKGROUND_COLORS: Record<ReservationStatus, string> = {
@@ -22,7 +23,8 @@ export const STATUS_BACKGROUND_COLORS: Record<ReservationStatus, string> = {
 	'group-two': '#d4cf40',
 	'special': '#d49abe',
 	'alert': '#e08a65',
-	'maintenance': '#a8b2be'
+	'maintenance': '#a8b2be',
+	'no-show': '#c49aaf'
 };
 
 export const STATUS_PATTERNS: Record<ReservationStatus, string> = {
@@ -32,7 +34,8 @@ export const STATUS_PATTERNS: Record<ReservationStatus, string> = {
 	'group-two': 'repeating-linear-gradient(0deg, transparent, transparent 4px, rgba(0,0,0,0.07) 4px, rgba(0,0,0,0.07) 6px), repeating-linear-gradient(90deg, transparent, transparent 4px, rgba(0,0,0,0.07) 4px, rgba(0,0,0,0.07) 6px)',
 	'special': 'repeating-linear-gradient(0deg, transparent, transparent 4px, rgba(0,0,0,0.08) 4px, rgba(0,0,0,0.08) 6px)',
 	'alert': 'repeating-linear-gradient(-45deg, transparent, transparent 3px, rgba(0,0,0,0.10) 3px, rgba(0,0,0,0.10) 5px)',
-	'maintenance': 'repeating-linear-gradient(90deg, transparent, transparent 4px, rgba(0,0,0,0.08) 4px, rgba(0,0,0,0.08) 6px)'
+	'maintenance': 'repeating-linear-gradient(90deg, transparent, transparent 4px, rgba(0,0,0,0.08) 4px, rgba(0,0,0,0.08) 6px)',
+	'no-show': 'repeating-linear-gradient(135deg, transparent, transparent 3px, rgba(0,0,0,0.12) 3px, rgba(0,0,0,0.12) 5px)'
 };
 
 export const STATUS_PATTERN_SIZES: Record<ReservationStatus, string> = {
@@ -42,7 +45,8 @@ export const STATUS_PATTERN_SIZES: Record<ReservationStatus, string> = {
 	'group-two': 'auto',
 	'special': 'auto',
 	'alert': 'auto',
-	'maintenance': 'auto'
+	'maintenance': 'auto',
+	'no-show': 'auto'
 };
 
 export const STATUS_ICONS: Record<ReservationStatus, string> = {
@@ -52,7 +56,8 @@ export const STATUS_ICONS: Record<ReservationStatus, string> = {
 	'group-two': '\u{1F46A}',
 	'special': '\u2B50',
 	'alert': '\u26A0\uFE0F',
-	'maintenance': '\u{1F527}'
+	'maintenance': '\u{1F527}',
+	'no-show': '\u{274C}'
 };
 
 export const STATUS_LABELS: Record<ReservationStatus, string> = {
@@ -62,7 +67,8 @@ export const STATUS_LABELS: Record<ReservationStatus, string> = {
 	'group-two': 'Group Two',
 	'special': 'Special',
 	'alert': 'Alert',
-	'maintenance': 'Maintenance'
+	'maintenance': 'Maintenance',
+	'no-show': 'No-Show'
 };
 
 export function isReservationStatus(value: string): value is ReservationStatus {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,7 @@ export const RESERVATION_COLORS = [
 
 export type ReservationColor = (typeof RESERVATION_COLORS)[number];
 
-export const RESERVATION_STATUSES = ['reserved', 'checked-in', 'group-one', 'group-two', 'special', 'alert', 'maintenance'] as const;
+export const RESERVATION_STATUSES = ['reserved', 'checked-in', 'group-one', 'group-two', 'special', 'alert', 'maintenance', 'no-show'] as const;
 
 export type ReservationStatus = (typeof RESERVATION_STATUSES)[number];
 

--- a/tests/e2e/no-show-status.spec.ts
+++ b/tests/e2e/no-show-status.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function resetApp(page: Page) {
+	await page.goto('/');
+	await page.evaluate(() => window.localStorage.clear());
+	await page.reload();
+	await page.waitForSelector('.toolbar-title');
+	await page.waitForTimeout(300);
+}
+
+function offsetDate(days: number): string {
+	const d = new Date();
+	d.setDate(d.getDate() + days);
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const dd = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${dd}`;
+}
+
+const modal = (page: Page) => page.locator('.modal[role="dialog"]');
+
+async function clickCellAtDate(page: Page, dateIso: string, rowIndex = 0) {
+	const colIndex = await page.evaluate((date) => {
+		const headers = document.querySelectorAll('th.date-header[data-date]');
+		for (let i = 0; i < headers.length; i++) {
+			if (headers[i].getAttribute('data-date') === date) return i;
+		}
+		return -1;
+	}, dateIso);
+	if (colIndex === -1) throw new Error(`Date column ${dateIso} not found in grid`);
+
+	const cell = page.locator('tbody tr').nth(rowIndex).locator('td.grid-cell').nth(colIndex);
+	await cell.scrollIntoViewIfNeeded();
+	await cell.click();
+}
+
+test.describe('No-show reservation status', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('no-show status appears in reservation modal dropdown', async ({ page }) => {
+		await page.click('[data-testid="new-reservation-btn"]');
+		await expect(modal(page)).toBeVisible();
+
+		const statusSelect = modal(page).locator('select[aria-label="Reservation status"]');
+		const options = statusSelect.locator('option');
+
+		// Should have 8 statuses including no-show
+		await expect(options).toHaveCount(8);
+
+		// Verify no-show is one of the options
+		const optionTexts = await options.allTextContents();
+		expect(optionTexts).toContain('No-Show');
+	});
+
+	test('no-show status appears in legend', async ({ page }) => {
+		const legend = page.locator('.status-legend');
+		await expect(legend).toContainText('No-Show');
+	});
+
+	test('reservation can be created with no-show status', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(3);
+
+		await clickCellAtDate(page, today, 0);
+		await expect(modal(page)).toBeVisible();
+
+		await modal(page).locator('[data-testid="guest-name-input"]').fill('No Show Guest');
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+		await modal(page).locator('select[aria-label="Reservation status"]').selectOption('no-show');
+
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+
+		// Verify the cell is occupied
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.scrollIntoViewIfNeeded();
+		await expect(occupied.locator('.reservation-label')).toContainText('No Show Guest');
+	});
+
+	test('no-show reservation has distinct styling on grid', async ({ page }) => {
+		const today = offsetDate(0);
+		const endDate = offsetDate(3);
+
+		await clickCellAtDate(page, today, 0);
+		await expect(modal(page)).toBeVisible();
+
+		await modal(page).locator('[data-testid="guest-name-input"]').fill('Ghost Guest');
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+		await modal(page).locator('select[aria-label="Reservation status"]').selectOption('no-show');
+
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+
+		// Verify the occupied cell has a background-color style (from status styling)
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.scrollIntoViewIfNeeded();
+		const bgColor = await occupied.evaluate((el) => el.style.backgroundColor);
+		expect(bgColor).not.toBe('');
+
+		// Verify it has a background-image (the stripe pattern)
+		const bgImage = await occupied.evaluate((el) => el.style.backgroundImage);
+		expect(bgImage).not.toBe('none');
+		expect(bgImage).not.toBe('');
+	});
+});

--- a/tests/unit/status-migration.test.ts
+++ b/tests/unit/status-migration.test.ts
@@ -15,8 +15,8 @@ import { RESERVATION_STATUSES } from '$lib/types';
 import { sanitizeReservation } from '$lib/storage';
 
 describe('ReservationStatus type', () => {
-	it('defines exactly seven statuses', () => {
-		expect(RESERVATION_STATUSES).toEqual(['reserved', 'checked-in', 'group-one', 'group-two', 'special', 'alert', 'maintenance']);
+	it('defines exactly eight statuses', () => {
+		expect(RESERVATION_STATUSES).toEqual(['reserved', 'checked-in', 'group-one', 'group-two', 'special', 'alert', 'maintenance', 'no-show']);
 	});
 
 	it('default status is reserved', () => {

--- a/tests/unit/status-migration.test.ts
+++ b/tests/unit/status-migration.test.ts
@@ -33,6 +33,7 @@ describe('isReservationStatus', () => {
 		expect(isReservationStatus('special')).toBe(true);
 		expect(isReservationStatus('alert')).toBe(true);
 		expect(isReservationStatus('maintenance')).toBe(true);
+		expect(isReservationStatus('no-show')).toBe(true);
 	});
 
 	it('returns false for invalid statuses', () => {
@@ -75,6 +76,10 @@ describe('STATUS_COLORS (Wong colorblind-safe palette)', () => {
 	it('maps maintenance to gray (#7B8A99)', () => {
 		expect(STATUS_COLORS['maintenance']).toBe('#7B8A99');
 	});
+
+	it('maps no-show to purple (#882255)', () => {
+		expect(STATUS_COLORS['no-show']).toBe('#882255');
+	});
 });
 
 describe('STATUS_BACKGROUND_COLORS', () => {
@@ -95,6 +100,7 @@ describe('STATUS_LABELS', () => {
 		expect(STATUS_LABELS['special']).toBe('Special');
 		expect(STATUS_LABELS['alert']).toBe('Alert');
 		expect(STATUS_LABELS['maintenance']).toBe('Maintenance');
+		expect(STATUS_LABELS['no-show']).toBe('No-Show');
 	});
 });
 
@@ -107,6 +113,7 @@ describe('getStatusColor', () => {
 		expect(getStatusColor('special')).toBe('#CC79A7');
 		expect(getStatusColor('alert')).toBe('#D55E00');
 		expect(getStatusColor('maintenance')).toBe('#7B8A99');
+		expect(getStatusColor('no-show')).toBe('#882255');
 	});
 });
 


### PR DESCRIPTION
## Summary
- Add `no-show` as the eighth reservation status
- Muted purple color (#882255) with diagonal stripe pattern
- Cross mark icon (❌) for quick visual identification
- Appears in status select dropdown, legend, and grid cells

## Why
Client expressed frustration about no-show guests. This status lets operators mark reservations where guests didn't arrive, enabling future tracking of unreliable customers.

## Test plan
- [ ] Open reservation modal — "No-Show" appears in status dropdown
- [ ] Select No-Show status — verify purple striped cell style in grid
- [ ] Status legend shows No-Show entry
- [ ] Existing statuses still work correctly
- [ ] Unit tests pass: `npm run test:unit`