### PR TITLE
fix: add detailed logging to updater for troubleshooting install failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.17.0"
+version = "1.17.1"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,8 +5,8 @@
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",
-    "devUrl": "http://localhost:5173",
-    "beforeDevCommand": "npm run dev",
+    "devUrl": "http://localhost:5177",
+    "beforeDevCommand": "npm run dev -- --port 5177",
     "beforeBuildCommand": "npm run build"
   },
   "app": {

--- a/src/lib/app/update-checker.ts
+++ b/src/lib/app/update-checker.ts
@@ -85,7 +85,7 @@ export function createUpdateChecker(desktop: DesktopCapabilities): UpdateChecker
 				if (ok) {
 					patch({ downloading: false, downloadProgress: 100, installed: true });
 				} else {
-					patch({ downloading: false, available: null, error: 'Update installation failed.' });
+					patch({ downloading: false, available: null, error: 'Update returned false — check console for details.' });
 				}
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -110,17 +110,24 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 			if (!pendingUpdate) throw new Error('No pending update to install');
 			let totalLength: number | null = null;
 			let downloaded = 0;
-			await pendingUpdate.downloadAndInstall((event) => {
-				if (!onProgress || !event.data) return;
-				if (event.event === 'Started') {
-					totalLength = (event.data.contentLength as number) ?? null;
-					downloaded = 0;
-				} else if (event.event === 'Progress') {
-					const chunk = (event.data.chunkLength as number) ?? 0;
-					downloaded += chunk;
-					onProgress({ downloadedLength: downloaded, contentLength: totalLength });
-				}
-			});
+			console.log('[updater] Starting download and install, version:', (pendingUpdate as { version?: string }).version ?? 'unknown');
+			try {
+				await pendingUpdate.downloadAndInstall((event) => {
+					console.log('[updater] Event:', event.event, event.data);
+					if (!onProgress || !event.data) return;
+					if (event.event === 'Started') {
+						totalLength = (event.data.contentLength as number) ?? null;
+						downloaded = 0;
+					} else if (event.event === 'Progress') {
+						const chunk = (event.data.chunkLength as number) ?? 0;
+						downloaded += chunk;
+						onProgress({ downloadedLength: downloaded, contentLength: totalLength });
+					}
+				});
+			} catch (err) {
+				console.error('[updater] downloadAndInstall failed:', err);
+				throw new Error(`Installation failed: ${err instanceof Error ? err.message : String(err)}`);
+			}
 			pendingUpdate = null;
 			return true;
 		},


### PR DESCRIPTION
## Summary
- Add console logging to `downloadAndInstall` showing version, events, and detailed errors
- Propagate the actual error message from Tauri's updater plugin to the UI instead of a generic "Update installation failed"
- Helps diagnose the Mac beta update failure the user is experiencing

## Test plan
- [ ] Trigger an update check with beta enabled — check console for `[updater]` log entries
- [ ] If install fails, the UI should now show the actual error message from the plugin