### PR TITLE
chore: drop Linux AppImage build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,6 @@ jobs:
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
             args: ''
-          - platform: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-            args: '--bundles appimage'
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
@@ -71,12 +68,6 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-
-      - name: Install Linux dependencies
-        if: matrix.platform == 'ubuntu-22.04'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev
 
       - run: npm ci
 
@@ -104,7 +95,6 @@ jobs:
             src-tauri/target/**/release/bundle/**/*.msi
             src-tauri/target/**/release/bundle/**/*.exe
             src-tauri/target/**/release/bundle/**/*.nsis.zip
-            src-tauri/target/**/release/bundle/appimage/*.AppImage
             src-tauri/target/**/release/bundle/**/*.sig
           if-no-files-found: warn
           retention-days: 30

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.17.1"
+version = "1.17.2"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary
- Remove the Linux/Ubuntu matrix entry from `release.yml` so we only build Windows MSI/EXE and macOS universal DMG
- Drop the Linux apt dependency install step and the AppImage path from artifact upload
- Bump to 1.17.2 (CI requires a version bump on PRs)

## Why
Project only ships to Windows and macOS clients. Linux build was ~5min of pipeline time per release with no consumer.

## Test plan
- [ ] CI passes (typecheck + build + Playwright)
- [ ] Confirm release workflow on the next tag builds only Windows + macOS artifacts