### PR TITLE
feat: indicate available vs booked sites in reservation modal dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.17.2",
+  "version": "1.18.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.17.2"
+version = "1.18.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.17.2",
+  "version": "1.18.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/components/ReservationModal.svelte
+++ b/src/lib/components/ReservationModal.svelte
@@ -3,7 +3,8 @@
   import { addDays, compareIsoDates, diffDays } from '$lib/date';
   import { MAX_RESERVATION_NOTES_LENGTH } from '$lib/reservations';
   import { STATUS_LABELS, getStatusSwatchStyle } from '$lib/domain/reservations/status';
-  import { RESERVATION_STATUSES, type ReservationFormValues, type ReservationStatus } from '$lib/types';
+  import { RESERVATION_STATUSES, type Reservation, type ReservationFormValues, type ReservationStatus } from '$lib/types';
+  import { computeLocationAvailability } from '$lib/domain/reservations/availability';
   import type { Customer } from '$lib/domain/customers';
   import AutocompleteInput from './AutocompleteInput.svelte';
   import DateRangeCalendar from './DateRangeCalendar.svelte';
@@ -11,6 +12,7 @@
   export let open = false;
   export let mode: 'create' | 'edit' = 'create';
   export let parkingLocations: string[] = [];
+  export let existingReservations: Reservation[] = [];
   export let customers: Customer[] = [];
   export let draft: ReservationFormValues = {
     name: '',
@@ -39,6 +41,16 @@
   let confirmingDelete = false;
   let autocompleteRef: AutocompleteInput;
   let wasOpen = false;
+
+  $: availabilityByLocation = new Map(
+    computeLocationAvailability(
+      form.startDate,
+      form.endDate,
+      parkingLocations,
+      existingReservations,
+      form.index
+    ).map((a) => [a.location, a])
+  );
 
   $: customerSuggestions = customers.map((c) => ({
     label: c.name,
@@ -266,9 +278,13 @@
 
             <label>
               <span>Site</span>
-              <select bind:value={form.parkingLocation} required>
+              <select bind:value={form.parkingLocation} required data-testid="site-select">
                 {#each parkingLocations as location}
-                  <option value={location}>{location}</option>
+                  {@const availability = availabilityByLocation.get(location)}
+                  {@const isBooked = availability ? !availability.isAvailable : false}
+                  <option value={location} disabled={isBooked && location !== form.parkingLocation}>
+                    {location}{isBooked ? ' — booked' : ''}
+                  </option>
                 {/each}
               </select>
             </label>

--- a/src/lib/domain/reservations/availability.ts
+++ b/src/lib/domain/reservations/availability.ts
@@ -1,0 +1,50 @@
+import { isIsoDateString, compareIsoDates } from '$lib/date';
+import type { Reservation } from '$lib/domain/models';
+import { checkOverlap } from './validation';
+
+export interface LocationAvailability {
+	location: string;
+	isAvailable: boolean;
+	conflictingReservationIndex?: number;
+}
+
+/**
+ * For each parking location, determine whether it is free for the given date range.
+ * Returns all locations as available when the date range is missing or invalid,
+ * matching the modal's "no decoration until both dates are valid" behavior.
+ */
+export function computeLocationAvailability(
+	startDate: string,
+	endDate: string,
+	parkingLocations: string[],
+	existingReservations: Reservation[],
+	excludeReservationIndex?: number
+): LocationAvailability[] {
+	const rangeIsValid =
+		isIsoDateString(startDate) &&
+		isIsoDateString(endDate) &&
+		compareIsoDates(startDate, endDate) < 0;
+
+	if (!rangeIsValid) {
+		return parkingLocations.map((location) => ({ location, isAvailable: true }));
+	}
+
+	return parkingLocations.map((location) => {
+		for (const reservation of existingReservations) {
+			if (typeof excludeReservationIndex === 'number' && reservation.index === excludeReservationIndex) {
+				continue;
+			}
+			if (reservation.parkingLocation !== location) {
+				continue;
+			}
+			if (checkOverlap(startDate, endDate, reservation.startDate, reservation.endDate)) {
+				return {
+					location,
+					isAvailable: false,
+					conflictingReservationIndex: reservation.index
+				};
+			}
+		}
+		return { location, isAvailable: true };
+	});
+}

--- a/src/lib/domain/reservations/index.ts
+++ b/src/lib/domain/reservations/index.ts
@@ -33,5 +33,8 @@ export {
 	validateReservationForm
 } from './validation';
 
+export { computeLocationAvailability } from './availability';
+export type { LocationAvailability } from './availability';
+
 export { filterReservations } from './search';
 export type { SearchResult } from './search';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -892,6 +892,7 @@
   draft={modalDraft}
   errors={modalErrors}
   parkingLocations={$rvReservationStore.parkingLocations}
+  existingReservations={$rvReservationStore.reservations}
   customers={$customerStore}
   triggerElement={modalTriggerElement}
   on:save={handleModalSave}

--- a/tests/e2e/reservations.spec.ts
+++ b/tests/e2e/reservations.spec.ts
@@ -612,3 +612,73 @@ test.describe('Date picker UX', () => {
 		await expect(modal(page).locator('[data-testid="nights-display"]')).toContainText('3 nights');
 	});
 });
+
+test.describe('Site availability indicator (#134)', () => {
+	test.beforeEach(async ({ page }) => {
+		await resetApp(page);
+	});
+
+	test('marks the conflicting site as booked and disables it', async ({ page }) => {
+		const start = offsetDate(5);
+		const end = offsetDate(8);
+
+		await createReservation(page, { name: 'Existing Guest', startDate: start, endDate: end, rowIndex: 0 });
+
+		// Open new-reservation modal on a different row.
+		await clickCellAtDate(page, getTodayIso(), 1);
+		await expect(modal(page)).toBeVisible();
+
+		const startInput = modal(page).locator('input[type="date"]').first();
+		const endInput = modal(page).locator('input[type="date"]').nth(1);
+		await startInput.fill(start);
+		await endInput.fill(end);
+
+		const siteSelect = modal(page).locator('[data-testid="site-select"]');
+		const firstSite = await siteSelect.locator('option').nth(0).getAttribute('value');
+		expect(firstSite).toBeTruthy();
+
+		const bookedOption = siteSelect.locator(`option[value="${firstSite}"]`);
+		await expect(bookedOption).toContainText('booked');
+		await expect(bookedOption).toHaveAttribute('disabled', '');
+	});
+
+	test('clears the booked indicator when dates no longer conflict', async ({ page }) => {
+		const start = offsetDate(5);
+		const end = offsetDate(8);
+
+		await createReservation(page, { name: 'Existing Guest', startDate: start, endDate: end, rowIndex: 0 });
+
+		await clickCellAtDate(page, getTodayIso(), 1);
+		await expect(modal(page)).toBeVisible();
+
+		const startInput = modal(page).locator('input[type="date"]').first();
+		const endInput = modal(page).locator('input[type="date"]').nth(1);
+		const siteSelect = modal(page).locator('[data-testid="site-select"]');
+		const firstSite = await siteSelect.locator('option').nth(0).getAttribute('value');
+
+		await startInput.fill(start);
+		await endInput.fill(end);
+		await expect(siteSelect.locator(`option[value="${firstSite}"]`)).toContainText('booked');
+
+		// Move dates well past the existing reservation.
+		await startInput.fill(offsetDate(20));
+		await endInput.fill(offsetDate(23));
+		await expect(siteSelect.locator(`option[value="${firstSite}"]`)).not.toContainText('booked');
+		await expect(siteSelect.locator(`option[value="${firstSite}"]`)).not.toHaveAttribute('disabled', '');
+	});
+
+	test('does not mark the reservation own site as booked when editing it', async ({ page }) => {
+		const start = offsetDate(5);
+		const end = offsetDate(8);
+
+		await createReservation(page, { name: 'Editable Guest', startDate: start, endDate: end, rowIndex: 0 });
+
+		// Re-open the reservation by clicking its starting cell.
+		await clickCellAtDate(page, start, 0);
+		await expect(modal(page)).toBeVisible();
+
+		const siteSelect = modal(page).locator('[data-testid="site-select"]');
+		const ownSite = await siteSelect.inputValue();
+		await expect(siteSelect.locator(`option[value="${ownSite}"]`)).not.toContainText('booked');
+	});
+});

--- a/tests/unit/availability.test.ts
+++ b/tests/unit/availability.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { computeLocationAvailability } from '$lib/domain/reservations/availability';
+import type { Reservation } from '$lib/types';
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+	return {
+		index: 1,
+		firstCellId: 'A|2025-06-01',
+		name: 'Guest',
+		rvType: '',
+		phoneNumber: '',
+		notes: '',
+		startDate: '2025-06-01',
+		endDate: '2025-06-05',
+		parkingLocation: 'Site A',
+		color: 'blue',
+		status: 'reserved',
+		...overrides
+	};
+}
+
+const LOCATIONS = ['Site A', 'Site B', 'Site C'];
+
+describe('computeLocationAvailability', () => {
+	it('returns all available when startDate is empty', () => {
+		const result = computeLocationAvailability('', '2025-06-05', LOCATIONS, [
+			makeReservation({ parkingLocation: 'Site A' })
+		]);
+		expect(result.every((r) => r.isAvailable)).toBe(true);
+	});
+
+	it('returns all available when endDate is empty', () => {
+		const result = computeLocationAvailability('2025-06-01', '', LOCATIONS, [
+			makeReservation({ parkingLocation: 'Site A' })
+		]);
+		expect(result.every((r) => r.isAvailable)).toBe(true);
+	});
+
+	it('returns all available when endDate is not after startDate', () => {
+		const result = computeLocationAvailability('2025-06-05', '2025-06-05', LOCATIONS, [
+			makeReservation({ parkingLocation: 'Site A' })
+		]);
+		expect(result.every((r) => r.isAvailable)).toBe(true);
+	});
+
+	it('returns all available when no existing reservations conflict', () => {
+		const result = computeLocationAvailability('2025-07-01', '2025-07-05', LOCATIONS, [
+			makeReservation({ parkingLocation: 'Site A', startDate: '2025-06-01', endDate: '2025-06-05' })
+		]);
+		expect(result.every((r) => r.isAvailable)).toBe(true);
+	});
+
+	it('marks the conflicting location as booked with the reservation index', () => {
+		const result = computeLocationAvailability('2025-06-02', '2025-06-04', LOCATIONS, [
+			makeReservation({ index: 42, parkingLocation: 'Site A' })
+		]);
+		const a = result.find((r) => r.location === 'Site A');
+		const b = result.find((r) => r.location === 'Site B');
+		expect(a).toEqual({ location: 'Site A', isAvailable: false, conflictingReservationIndex: 42 });
+		expect(b).toEqual({ location: 'Site B', isAvailable: true });
+	});
+
+	it('treats adjacent ranges as available (end is exclusive)', () => {
+		// Existing reservation ends 2025-06-05 (exclusive); new reservation starts 2025-06-05.
+		const result = computeLocationAvailability('2025-06-05', '2025-06-08', LOCATIONS, [
+			makeReservation({ parkingLocation: 'Site A', startDate: '2025-06-01', endDate: '2025-06-05' })
+		]);
+		expect(result.find((r) => r.location === 'Site A')?.isAvailable).toBe(true);
+	});
+
+	it('detects partial overlap on the trailing edge', () => {
+		const result = computeLocationAvailability('2025-06-04', '2025-06-08', LOCATIONS, [
+			makeReservation({ parkingLocation: 'Site A', startDate: '2025-06-01', endDate: '2025-06-05' })
+		]);
+		expect(result.find((r) => r.location === 'Site A')?.isAvailable).toBe(false);
+	});
+
+	it('excludes the reservation being edited from the conflict check', () => {
+		const result = computeLocationAvailability(
+			'2025-06-02',
+			'2025-06-04',
+			LOCATIONS,
+			[makeReservation({ index: 7, parkingLocation: 'Site A' })],
+			7
+		);
+		expect(result.find((r) => r.location === 'Site A')?.isAvailable).toBe(true);
+	});
+
+	it('returns the first conflicting reservation when multiple overlap', () => {
+		const result = computeLocationAvailability('2025-06-01', '2025-06-30', LOCATIONS, [
+			makeReservation({ index: 1, parkingLocation: 'Site A', startDate: '2025-06-02', endDate: '2025-06-05' }),
+			makeReservation({ index: 2, parkingLocation: 'Site A', startDate: '2025-06-10', endDate: '2025-06-12' })
+		]);
+		expect(result.find((r) => r.location === 'Site A')?.conflictingReservationIndex).toBe(1);
+	});
+
+	it('preserves the order of input parkingLocations', () => {
+		const result = computeLocationAvailability('2025-07-01', '2025-07-05', LOCATIONS, []);
+		expect(result.map((r) => r.location)).toEqual(LOCATIONS);
+	});
+});


### PR DESCRIPTION
Closes #134.

## Summary
- New domain helper `computeLocationAvailability` (`src/lib/domain/reservations/availability.ts`) that returns per-location availability for a given date range. Pure, reuses `checkOverlap` from `validation.ts`, supports `excludeReservationIndex` for the edit-self case.
- `ReservationModal` site dropdown now reactively marks each `<option>` as ` — booked` and disables it when the location conflicts with the selected dates.
- Currently-selected option stays enabled even if it becomes booked mid-edit, so the form stays coherent; existing save-side overlap rejection remains as the backstop.
- `+page.svelte` threads `existingReservations` into the modal.

## Behavior decisions (per planning)
- **Visual**: disabled `<option>` with ` — booked` suffix. Simple, accessible, can't be picked by mistake.
- **Empty / invalid dates**: render all sites neutrally (no decoration) until both dates are valid and the range is positive.
- **Edit flow**: self-exclusion via `excludeReservationIndex = form.index` so the editing reservation never marks its own site booked.
- Site colors integration deliberately deferred — out of scope.

## Test plan
- [x] `npm run check` — 0 errors (3 pre-existing a11y warnings on dialog roles, unrelated)
- [x] `npm run test:unit tests/unit/availability.test.ts` — 10/10 pass
- [x] `npx playwright test tests/e2e/reservations.spec.ts` — 31/31 pass (3 new + 28 existing)
- [ ] CI green
- [ ] Copilot review

## Note
There's a pre-existing failing unit test in `tests/unit/update-checker.test.ts` left over from PR #131's error-message change. Not related to this PR; CI doesn't run vitest so it's not blocking. Worth a separate one-line fix.