### PR TITLE
feat: increase notes limit and safer update restart flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.0",
+  "version": "1.19.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.19.0",
+      "version": "1.19.0-beta.1",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.17.1",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.17.1",
+      "version": "1.19.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.0-beta.1",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.19.0-beta.1",
+      "version": "1.19.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.0-beta.1",
+  "version": "1.19.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.0",
+  "version": "1.19.0-beta.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.19.0"
+version = "1.19.1"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.18.0"
+version = "1.19.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.19.0"
+version = "1.19.0-beta.1"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.19.1"
+version = "1.19.2"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.19.0-beta.1"
+version = "1.19.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.19.0",
+  "version": "1.19.0-beta.1",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.19.0-beta.1",
+  "version": "1.19.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/app/forced-backup.ts
+++ b/src/lib/app/forced-backup.ts
@@ -1,0 +1,46 @@
+import type { DesktopCapabilities } from '$lib/application/ports';
+import { generateBackupFilename } from '$lib/domain/backup';
+
+export const JSON_BACKUP_FILTERS = [{ name: 'JSON', extensions: ['json'] }];
+
+export type ForcedBackupResult =
+	| { ok: true }
+	| { ok: false; error: string };
+
+export interface ForcedBackupDeps {
+	desktop: DesktopCapabilities;
+	getBackupContent: () => string;
+	getAutoBackupDirectory: () => string | null | undefined;
+	onSuccess?: (timestamp: string) => Promise<void>;
+}
+
+function joinBackupPath(directoryPath: string, filename: string): string {
+	const separator = directoryPath.endsWith('/') || directoryPath.endsWith('\\') ? '' : '/';
+	return `${directoryPath}${separator}${filename}`;
+}
+
+function formatBackupError(error: unknown): string {
+	return `Backup failed: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+export async function createForcedBackup(deps: ForcedBackupDeps): Promise<ForcedBackupResult> {
+	const filename = generateBackupFilename();
+	const content = deps.getBackupContent();
+	const directoryPath = deps.getAutoBackupDirectory();
+
+	try {
+		if (directoryPath) {
+			await deps.desktop.writeFileToPath(joinBackupPath(directoryPath, filename), content);
+		} else {
+			const saved = await deps.desktop.saveFile(filename, content, JSON_BACKUP_FILTERS);
+			if (!saved) {
+				return { ok: false, error: 'Update blocked because backup was not saved.' };
+			}
+		}
+
+		await deps.onSuccess?.(new Date().toISOString());
+		return { ok: true };
+	} catch (error) {
+		return { ok: false, error: formatBackupError(error) };
+	}
+}

--- a/src/lib/app/update-checker.ts
+++ b/src/lib/app/update-checker.ts
@@ -6,15 +6,22 @@ export interface UpdateState {
 	available: UpdateInfo | null;
 	downloading: boolean;
 	downloadProgress: number;
-	installed: boolean;
+	readyToInstall: boolean;
+	installing: boolean;
 	error: string | null;
+}
+
+export type PreUpdateBackupResult = { ok: true } | { ok: false; error: string };
+
+export interface UpdateCheckerDeps {
+	createPreUpdateBackup?: () => Promise<PreUpdateBackupResult>;
 }
 
 export interface UpdateChecker {
 	state: Readable<UpdateState>;
 	checkForUpdate(beta?: boolean): Promise<void>;
-	downloadAndInstall(): Promise<void>;
-	relaunch(): Promise<void>;
+	downloadUpdate(): Promise<void>;
+	installUpdateAndRestart(): Promise<void>;
 }
 
 const GITHUB_RELEASES_URL =
@@ -38,11 +45,12 @@ const initial: UpdateState = {
 	available: null,
 	downloading: false,
 	downloadProgress: 0,
-	installed: false,
+	readyToInstall: false,
+	installing: false,
 	error: null
 };
 
-export function createUpdateChecker(desktop: DesktopCapabilities): UpdateChecker {
+export function createUpdateChecker(desktop: DesktopCapabilities, deps: UpdateCheckerDeps = {}): UpdateChecker {
 	const store = writable<UpdateState>({ ...initial });
 
 	function patch(partial: Partial<UpdateState>): void {
@@ -53,7 +61,7 @@ export function createUpdateChecker(desktop: DesktopCapabilities): UpdateChecker
 		state: { subscribe: store.subscribe },
 
 		async checkForUpdate(beta?: boolean) {
-			patch({ checking: true, error: null });
+			patch({ checking: true, error: null, readyToInstall: false });
 			try {
 				let info;
 				if (beta) {
@@ -66,36 +74,62 @@ export function createUpdateChecker(desktop: DesktopCapabilities): UpdateChecker
 				} else {
 					info = await desktop.checkForUpdate();
 				}
-				patch({ checking: false, available: info });
+				patch({ checking: false, available: info, downloadProgress: 0 });
 			} catch (err) {
-				patch({ checking: false, available: null, error: 'Failed to check for updates.' });
+				patch({ checking: false, available: null, readyToInstall: false, error: 'Failed to check for updates.' });
 				console.error('Update check error:', err);
 			}
 		},
 
-		async downloadAndInstall() {
-			patch({ downloading: true, downloadProgress: 0, error: null });
+		async downloadUpdate() {
+			patch({ downloading: true, readyToInstall: false, downloadProgress: 0, error: null });
 			try {
-				const ok = await desktop.downloadAndInstallUpdate((progress) => {
+				const ok = await desktop.downloadUpdate((progress) => {
 					if (progress.contentLength && progress.contentLength > 0) {
 						const pct = Math.round((progress.downloadedLength / progress.contentLength) * 100);
 						patch({ downloadProgress: Math.min(pct, 100) });
 					}
 				});
 				if (ok) {
-					patch({ downloading: false, downloadProgress: 100, installed: true });
+					patch({ downloading: false, downloadProgress: 100, readyToInstall: true });
 				} else {
-					patch({ downloading: false, available: null, error: 'Update returned false — check console for details.' });
+					patch({ downloading: false, error: 'Update download failed.' });
 				}
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : String(err);
-				patch({ downloading: false, available: null, error: `Update failed: ${msg}` });
+				patch({ downloading: false, error: `Update failed: ${msg}` });
 				console.error('Update error:', err);
 			}
 		},
 
-		async relaunch() {
-			await desktop.relaunch();
+		async installUpdateAndRestart() {
+			patch({ installing: true, error: null });
+			try {
+				const backup = deps.createPreUpdateBackup
+					? await deps.createPreUpdateBackup()
+					: { ok: false as const, error: 'Update blocked because backup is not configured.' };
+
+				if (!backup.ok) {
+					patch({ installing: false, readyToInstall: true, error: backup.error });
+					return;
+				}
+
+				const ok = await desktop.installUpdateAndRestart();
+				if (ok) {
+					patch({
+						installing: false,
+						readyToInstall: false,
+						available: null,
+						downloadProgress: 0
+					});
+				} else {
+					patch({ installing: false, readyToInstall: true, error: 'Update installation failed.' });
+				}
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				patch({ installing: false, readyToInstall: true, error: `Update failed: ${msg}` });
+				console.error('Update install error:', err);
+			}
 		}
 	};
 }

--- a/src/lib/application/ports/desktop.ts
+++ b/src/lib/application/ports/desktop.ts
@@ -47,8 +47,11 @@ export interface DesktopCapabilities {
 	/** Check for beta updates using a custom endpoint. Returns update info or null. */
 	checkBetaUpdate(endpoint: string): Promise<UpdateInfo | null>;
 
-	/** Download and install an available update. Returns true on success. */
-	downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean>;
+	/** Download an available update. Returns true when the update is ready to install. */
+	downloadUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean>;
+
+	/** Install a downloaded update and restart/relaunch where the platform allows. */
+	installUpdateAndRestart(): Promise<boolean>;
 
 	/** Relaunch the application after an update has been installed. */
 	relaunch(): Promise<void>;

--- a/src/lib/domain/reservations/normalization.ts
+++ b/src/lib/domain/reservations/normalization.ts
@@ -1,4 +1,4 @@
-export const MAX_RESERVATION_NOTES_LENGTH = 128;
+export const MAX_RESERVATION_NOTES_LENGTH = 5000;
 
 export function normalizeName(name: string): string {
 	return name.trim().replace(/\s+/g, ' ');

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -5,7 +5,8 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 		version: string;
 		date?: string | null;
 		body?: string | null;
-		downloadAndInstall(onEvent?: (event: { event: string; data?: Record<string, number | undefined> }) => void): Promise<void>;
+		download(onEvent?: (event: { event: string; data?: Record<string, number | undefined> }) => void): Promise<void>;
+		install(): Promise<void>;
 	}
 
 	let pendingUpdate: PendingUpdate | null = null;
@@ -91,9 +92,8 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 				pendingUpdate = null;
 				return null;
 			}
-			// Construct a standard Update object from the resource ID.
-			// This lets downloadAndInstall use the plugin's standard flow
-			// (proper progress events, on_before_exit, Windows process exit).
+			// Construct a standard Update object from the resource ID so the
+			// standard download/install flow can use the beta endpoint.
 			pendingUpdate = new Update({
 				...result,
 				date: result.date ?? undefined,
@@ -106,13 +106,13 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 				body: result.body
 			};
 		},
-		async downloadAndInstallUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
+		async downloadUpdate(onProgress?: (progress: UpdateProgress) => void): Promise<boolean> {
 			if (!pendingUpdate) throw new Error('No pending update to install');
 			let totalLength: number | null = null;
 			let downloaded = 0;
-			console.log('[updater] Starting download and install, version:', (pendingUpdate as { version?: string }).version ?? 'unknown');
+			console.log('[updater] Starting download, version:', (pendingUpdate as { version?: string }).version ?? 'unknown');
 			try {
-				await pendingUpdate.downloadAndInstall((event) => {
+				await pendingUpdate.download((event) => {
 					console.log('[updater] Event:', event.event, event.data);
 					if (!onProgress || !event.data) return;
 					if (event.event === 'Started') {
@@ -125,10 +125,23 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 					}
 				});
 			} catch (err) {
-				console.error('[updater] downloadAndInstall failed:', err);
+				console.error('[updater] download failed:', err);
+				throw new Error(`Download failed: ${err instanceof Error ? err.message : String(err)}`);
+			}
+			return true;
+		},
+		async installUpdateAndRestart(): Promise<boolean> {
+			if (!pendingUpdate) throw new Error('No downloaded update to install');
+			console.log('[updater] Starting install, version:', (pendingUpdate as { version?: string }).version ?? 'unknown');
+			try {
+				await pendingUpdate.install();
+				pendingUpdate = null;
+				const { relaunch } = await import('@tauri-apps/plugin-process');
+				await relaunch();
+			} catch (err) {
+				console.error('[updater] install failed:', err);
 				throw new Error(`Installation failed: ${err instanceof Error ? err.message : String(err)}`);
 			}
-			pendingUpdate = null;
 			return true;
 		},
 		async relaunch(): Promise<void> {

--- a/src/lib/infrastructure/desktop/web-fallback.ts
+++ b/src/lib/infrastructure/desktop/web-fallback.ts
@@ -38,7 +38,10 @@ export function createWebFallbackDesktopCapabilities(): DesktopCapabilities {
 		async checkBetaUpdate() {
 			return null;
 		},
-		async downloadAndInstallUpdate() {
+		async downloadUpdate() {
+			return false;
+		},
+		async installUpdateAndRestart() {
 			return false;
 		},
 		async relaunch() {},

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { onMount, setContext } from 'svelte';
   import { getAppServices, registerPersistenceLifecycleHandlers } from '$lib/app/composition';
   import { startAutoBackupTimer } from '$lib/app/auto-backup';
+  import { createForcedBackup } from '$lib/app/forced-backup';
   import { createUpdateChecker } from '$lib/app/update-checker';
   import { createBackup } from '$lib/domain/backup';
   import { siteSettingsStore } from '$lib/site-settings';
@@ -14,7 +15,22 @@
   // Create update checker at component init so setContext works for child routes.
   // The actual check is deferred to onMount after persistence is ready.
   const { desktop } = getAppServices();
-  const updateChecker = desktop.isDesktop ? createUpdateChecker(desktop) : null;
+  function getBackupContent(): string {
+    const state = get(rvReservationStore);
+    const settings = get(siteSettingsStore);
+    const customers = customerStore.getAll();
+    const backup = createBackup(state.reservations, state.parkingLocations, settings, customers);
+    return JSON.stringify(backup, null, 2);
+  }
+
+  const updateChecker = desktop.isDesktop ? createUpdateChecker(desktop, {
+    createPreUpdateBackup: () => createForcedBackup({
+      desktop,
+      getBackupContent,
+      getAutoBackupDirectory: () => get(siteSettingsStore).autoBackup?.directoryPath,
+      onSuccess: async (timestamp) => { await siteSettingsStore.recordAutoBackup(timestamp); }
+    })
+  }) : null;
   if (updateChecker) {
     setContext('updateChecker', updateChecker);
   }
@@ -41,13 +57,7 @@
           const settings = get(siteSettingsStore);
           return settings.autoBackup ?? { intervalMinutes: 0, directoryPath: null, lastBackupAt: null };
         },
-        getBackupContent: () => {
-          const state = get(rvReservationStore);
-          const settings = get(siteSettingsStore);
-          const customers = customerStore.getAll();
-          const backup = createBackup(state.reservations, state.parkingLocations, settings, customers);
-          return JSON.stringify(backup, null, 2);
-        },
+        getBackupContent,
         desktop,
         onSuccess: async (timestamp) => { await siteSettingsStore.recordAutoBackup(timestamp); },
         onError: (err) => console.error('Auto-backup failed:', err)

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -31,7 +31,15 @@
   let appVersion = '';
   let isDesktop = false;
   const updateChecker = getContext<UpdateChecker | undefined>('updateChecker');
-  const noUpdateState: UpdateState = { checking: false, available: null, downloading: false, downloadProgress: 0, installed: false, error: null };
+  const noUpdateState: UpdateState = {
+    checking: false,
+    available: null,
+    downloading: false,
+    downloadProgress: 0,
+    readyToInstall: false,
+    installing: false,
+    error: null
+  };
   const updateState = updateChecker?.state ?? readable(noUpdateState);
 
   let siteNameDraft = DEFAULT_SITE_NAME;
@@ -513,12 +521,16 @@
         <p>Current version: {appVersion || 'unknown'}</p>
 
         <div class="stack">
-          {#if $updateState.installed}
-            <div class="update-status success" data-testid="update-installed">
-              Update installed. Restart to apply.
+          {#if $updateState.installing}
+            <div class="update-status" data-testid="update-installing">
+              Creating backup and applying update...
             </div>
-            <button type="button" class="primary" on:click={() => updateChecker.relaunch()} data-testid="update-restart-btn">
-              Restart Now
+          {:else if $updateState.readyToInstall}
+            <div class="update-status success" data-testid="update-ready">
+              Update ready. Restart to apply.
+            </div>
+            <button type="button" class="primary" on:click={() => updateChecker.installUpdateAndRestart()} data-testid="update-apply-btn">
+              Restart &amp; Apply Update
             </button>
           {:else if $updateState.downloading}
             <div class="update-status" data-testid="update-downloading">
@@ -534,8 +546,8 @@
                 <span class="beta-badge">Beta</span>
               {/if}
             </div>
-            <button type="button" class="primary" on:click={() => updateChecker.downloadAndInstall()} data-testid="update-download-btn">
-              Download &amp; Install
+            <button type="button" class="primary" on:click={() => updateChecker.downloadUpdate()} data-testid="update-download-btn">
+              Download Update
             </button>
           {:else if $updateState.checking}
             <div class="update-status" data-testid="update-checking">

--- a/tests/e2e/reservations.spec.ts
+++ b/tests/e2e/reservations.spec.ts
@@ -201,6 +201,35 @@ test.describe('Modal accessibility and UX', () => {
 		await modal(page).locator('input[type="date"]').nth(1).fill(offsetDate(1));
 		await expect(nightsDisplay).toHaveText('1 night');
 	});
+
+	test('reservation notes support pasted email-length content', async ({ page }) => {
+		const today = getTodayIso();
+		const endDate = offsetDate(2);
+		const longNotes = 'N'.repeat(5000);
+
+		await page.getByTestId('new-reservation-btn').click();
+		await expect(modal(page)).toBeVisible();
+
+		const notesInput = modal(page).locator('textarea');
+		const notesCounter = modal(page).locator('.notes-label-row small');
+		await expect(notesInput).toHaveAttribute('maxlength', '5000');
+		await expect(notesCounter).toHaveText('0/5000');
+
+		await modal(page).locator('input[placeholder="Guest name"]').fill('Long Notes Guest');
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+		await notesInput.fill(longNotes);
+		await expect(notesCounter).toHaveText('5000/5000');
+
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.scrollIntoViewIfNeeded();
+		await occupied.click();
+		await expect(modal(page)).toBeVisible();
+		await expect(modal(page).locator('textarea')).toHaveValue(longNotes);
+	});
 });
 
 test.describe('New Reservation button', () => {

--- a/tests/unit/auto-backup.test.ts
+++ b/tests/unit/auto-backup.test.ts
@@ -58,7 +58,8 @@ describe('startAutoBackupTimer', () => {
 				pickDirectory: async () => null,
 				checkForUpdate: async () => null,
 				checkBetaUpdate: async () => null,
-				downloadAndInstallUpdate: async () => false,
+				downloadUpdate: async () => false,
+				installUpdateAndRestart: async () => false,
 				relaunch: async () => {}
 			},
 			onSuccess: async () => {},
@@ -109,7 +110,8 @@ describe('startAutoBackupTimer', () => {
 				pickDirectory: async () => null,
 				checkForUpdate: async () => null,
 				checkBetaUpdate: async () => null,
-				downloadAndInstallUpdate: async () => false,
+				downloadUpdate: async () => false,
+				installUpdateAndRestart: async () => false,
 				relaunch: async () => {}
 			}
 		});

--- a/tests/unit/forced-backup.test.ts
+++ b/tests/unit/forced-backup.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createForcedBackup, JSON_BACKUP_FILTERS } from '$lib/app/forced-backup';
+import type { DesktopCapabilities } from '$lib/application/ports';
+
+function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapabilities {
+	return {
+		isDesktop: true,
+		getAppDataDir: async () => null,
+		getVersion: async () => null,
+		saveFile: async () => false,
+		openFile: async () => null,
+		writeFileToPath: async () => {},
+		pickDirectory: async () => null,
+		checkForUpdate: async () => null,
+		checkBetaUpdate: async () => null,
+		downloadUpdate: async () => false,
+		installUpdateAndRestart: async () => false,
+		relaunch: async () => {},
+		...overrides
+	};
+}
+
+describe('createForcedBackup', () => {
+	it('writes to the configured backup directory and records success', async () => {
+		const writeFileToPath = vi.fn(async (_path: string, _content: string) => {});
+		const onSuccess = vi.fn(async () => {});
+
+		const result = await createForcedBackup({
+			desktop: makeDesktop({ writeFileToPath }),
+			getBackupContent: () => '{"ok":true}',
+			getAutoBackupDirectory: () => '/backups',
+			onSuccess
+		});
+
+		expect(result.ok).toBe(true);
+		expect(writeFileToPath).toHaveBeenCalledOnce();
+		const [path, content] = writeFileToPath.mock.calls[0];
+		expect(path).toMatch(/^\/backups\/rv-backup-\d{4}-\d{2}-\d{2}-\d{6}\.json$/);
+		expect(content).toBe('{"ok":true}');
+		expect(onSuccess).toHaveBeenCalledOnce();
+	});
+
+	it('opens a save dialog when no backup directory is configured', async () => {
+		const saveFile = vi.fn(async (_filename: string, _content: string, _filters?: { name: string; extensions: string[] }[]) => true);
+
+		const result = await createForcedBackup({
+			desktop: makeDesktop({ saveFile }),
+			getBackupContent: () => '{"ok":true}',
+			getAutoBackupDirectory: () => null
+		});
+
+		expect(result.ok).toBe(true);
+		expect(saveFile).toHaveBeenCalledOnce();
+		const [filename, content, filters] = saveFile.mock.calls[0];
+		expect(filename).toMatch(/^rv-backup-\d{4}-\d{2}-\d{2}-\d{6}\.json$/);
+		expect(content).toBe('{"ok":true}');
+		expect(filters).toEqual(JSON_BACKUP_FILTERS);
+	});
+
+	it('blocks when the user cancels the save dialog', async () => {
+		const result = await createForcedBackup({
+			desktop: makeDesktop({ saveFile: async () => false }),
+			getBackupContent: () => '{"ok":true}',
+			getAutoBackupDirectory: () => null
+		});
+
+		expect(result).toEqual({
+			ok: false,
+			error: 'Update blocked because backup was not saved.'
+		});
+	});
+
+	it('blocks when writing the backup fails', async () => {
+		const result = await createForcedBackup({
+			desktop: makeDesktop({
+				writeFileToPath: async () => {
+					throw new Error('disk full');
+				}
+			}),
+			getBackupContent: () => '{"ok":true}',
+			getAutoBackupDirectory: () => '/backups'
+		});
+
+		expect(result).toEqual({
+			ok: false,
+			error: 'Backup failed: disk full'
+		});
+	});
+});

--- a/tests/unit/reservation-notes.test.ts
+++ b/tests/unit/reservation-notes.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+	MAX_RESERVATION_NOTES_LENGTH,
+	sanitizeReservationNotes,
+	validateReservationForm
+} from '$lib/domain/reservations';
+import type { ReservationFormValues } from '$lib/types';
+import { sanitizeReservation } from '$lib/storage';
+
+function makeForm(overrides: Partial<ReservationFormValues> = {}): ReservationFormValues {
+	return {
+		name: 'Long Notes Guest',
+		rvType: '',
+		phoneNumber: '',
+		notes: '',
+		startDate: '2026-06-01',
+		endDate: '2026-06-03',
+		parkingLocation: 'A-01',
+		color: 'blue',
+		status: 'reserved',
+		...overrides
+	};
+}
+
+function makeStoredReservation(notes: string): Record<string, unknown> {
+	return {
+		index: 1,
+		firstCellId: 'A-01::2026-06-01',
+		name: 'Long Notes Guest',
+		rvType: '',
+		phoneNumber: '',
+		notes,
+		startDate: '2026-06-01',
+		endDate: '2026-06-03',
+		parkingLocation: 'A-01',
+		color: 'blue',
+		status: 'reserved'
+	};
+}
+
+describe('reservation notes limit', () => {
+	it('accepts notes at the 5,000 character limit', () => {
+		const notes = 'N'.repeat(5000);
+
+		const errors = validateReservationForm(makeForm({ notes }), {
+			existingReservations: [],
+			parkingLocations: ['A-01']
+		});
+
+		expect(MAX_RESERVATION_NOTES_LENGTH).toBe(5000);
+		expect(errors).not.toContain('Notes must be 5000 characters or fewer.');
+	});
+
+	it('rejects notes over the 5,000 character limit', () => {
+		const notes = 'N'.repeat(5001);
+
+		const errors = validateReservationForm(makeForm({ notes }), {
+			existingReservations: [],
+			parkingLocations: ['A-01']
+		});
+
+		expect(errors).toContain('Notes must be 5000 characters or fewer.');
+	});
+
+	it('truncates sanitized reservation notes to 5,000 characters', () => {
+		const notes = sanitizeReservationNotes('N'.repeat(5001));
+
+		expect(notes).toHaveLength(5000);
+	});
+
+	it('preserves stored reservation notes up to 5,000 characters', () => {
+		const notes = 'N'.repeat(5000);
+
+		const reservation = sanitizeReservation(makeStoredReservation(notes));
+
+		expect(reservation?.notes).toBe(notes);
+	});
+});

--- a/tests/unit/startup-migrations.test.ts
+++ b/tests/unit/startup-migrations.test.ts
@@ -14,7 +14,8 @@ function makeStubServices(): AppServices {
 			pickDirectory: async () => null,
 			checkForUpdate: async () => null,
 			checkBetaUpdate: async () => null,
-			downloadAndInstallUpdate: async () => false,
+			downloadUpdate: async () => false,
+			installUpdateAndRestart: async () => false,
 			relaunch: async () => {}
 		},
 		repositories: {

--- a/tests/unit/update-checker.test.ts
+++ b/tests/unit/update-checker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { get } from 'svelte/store';
-import { createUpdateChecker, type UpdateChecker } from '$lib/app/update-checker';
+import { createUpdateChecker } from '$lib/app/update-checker';
 import type { DesktopCapabilities, UpdateInfo } from '$lib/application/ports';
 
 function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapabilities {
@@ -14,7 +14,8 @@ function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapab
 		pickDirectory: async () => null,
 		checkForUpdate: async () => null,
 		checkBetaUpdate: async () => null,
-		downloadAndInstallUpdate: async () => false,
+		downloadUpdate: async () => false,
+		installUpdateAndRestart: async () => false,
 		relaunch: async () => {},
 		...overrides
 	};
@@ -34,7 +35,8 @@ describe('createUpdateChecker', () => {
 		expect(state.checking).toBe(false);
 		expect(state.available).toBeNull();
 		expect(state.downloading).toBe(false);
-		expect(state.installed).toBe(false);
+		expect(state.installing).toBe(false);
+		expect(state.readyToInstall).toBe(false);
 		expect(state.error).toBeNull();
 	});
 
@@ -72,42 +74,76 @@ describe('createUpdateChecker', () => {
 		expect(state.error).toBe('Failed to check for updates.');
 	});
 
-	it('downloadAndInstall tracks progress and sets installed', async () => {
+	it('downloadUpdate tracks progress and marks the update ready to install', async () => {
 		const checker = createUpdateChecker(makeDesktop({
 			checkForUpdate: async () => fakeUpdate,
-			downloadAndInstallUpdate: async () => true
+			downloadUpdate: async (onProgress) => {
+				onProgress?.({ downloadedLength: 50, contentLength: 100 });
+				return true;
+			}
 		}));
 
 		await checker.checkForUpdate();
-		await checker.downloadAndInstall();
+		await checker.downloadUpdate();
 
 		const state = get(checker.state);
 		expect(state.downloading).toBe(false);
-		expect(state.installed).toBe(true);
+		expect(state.downloadProgress).toBe(100);
+		expect(state.readyToInstall).toBe(true);
 	});
 
-	it('downloadAndInstall sets error on failure', async () => {
+	it('downloadUpdate sets error on failure', async () => {
 		const checker = createUpdateChecker(makeDesktop({
 			checkForUpdate: async () => fakeUpdate,
-			downloadAndInstallUpdate: async () => false
+			downloadUpdate: async () => false
 		}));
 
 		await checker.checkForUpdate();
-		await checker.downloadAndInstall();
+		await checker.downloadUpdate();
 
 		const state = get(checker.state);
 		expect(state.downloading).toBe(false);
-		expect(state.installed).toBe(false);
-		expect(state.error).toBe('Update installation failed.');
+		expect(state.readyToInstall).toBe(false);
+		expect(state.error).toBe('Update download failed.');
 	});
 
-	it('relaunch calls desktop.relaunch', async () => {
-		const relaunchFn = vi.fn();
+	it('installUpdateAndRestart creates a backup before installing', async () => {
+		const installFn = vi.fn(async () => true);
+		const backupFn = vi.fn(async () => ({ ok: true as const }));
 		const checker = createUpdateChecker(makeDesktop({
-			relaunch: relaunchFn
-		}));
+			checkForUpdate: async () => fakeUpdate,
+			downloadUpdate: async () => true,
+			installUpdateAndRestart: installFn
+		}), { createPreUpdateBackup: backupFn });
 
-		await checker.relaunch();
-		expect(relaunchFn).toHaveBeenCalledOnce();
+		await checker.checkForUpdate();
+		await checker.downloadUpdate();
+		await checker.installUpdateAndRestart();
+
+		expect(backupFn).toHaveBeenCalledOnce();
+		expect(installFn).toHaveBeenCalledOnce();
+		expect(backupFn.mock.invocationCallOrder[0]).toBeLessThan(installFn.mock.invocationCallOrder[0]);
+		expect(get(checker.state).readyToInstall).toBe(false);
+	});
+
+	it('installUpdateAndRestart blocks installation when backup fails', async () => {
+		const installFn = vi.fn(async () => true);
+		const checker = createUpdateChecker(makeDesktop({
+			checkForUpdate: async () => fakeUpdate,
+			downloadUpdate: async () => true,
+			installUpdateAndRestart: installFn
+		}), {
+			createPreUpdateBackup: async () => ({ ok: false, error: 'Backup failed: disk full' })
+		});
+
+		await checker.checkForUpdate();
+		await checker.downloadUpdate();
+		await checker.installUpdateAndRestart();
+
+		const state = get(checker.state);
+		expect(installFn).not.toHaveBeenCalled();
+		expect(state.installing).toBe(false);
+		expect(state.readyToInstall).toBe(true);
+		expect(state.error).toBe('Backup failed: disk full');
 	});
 });


### PR DESCRIPTION
## Summary
- split updater download from install/restart so macOS and Windows both show a ready-to-apply step
- force a backup immediately before update installation and block install if the backup is cancelled or fails
- preserve stable and beta update checks while using Tauri download() then install()

Refs #142

## Verification
- npm run test:unit -- tests/unit/update-checker.test.ts tests/unit/forced-backup.test.ts tests/unit/auto-backup.test.ts tests/unit/startup-migrations.test.ts
- npm run test:unit
- npm run check
- npm run build
- npm run test:e2e -- admin.spec.ts --project=chromium --workers=1
- Playwright screenshots: screenshots/issue-142-admin-baseline.png, screenshots/issue-142-admin-after.png

## Notes
- Existing Svelte modal a11y warnings and Rollup codeSplitting warning still appear during check/build.
- The update panel is desktop-only, so screenshots validate the web admin page did not regress visually.