### PR TITLE
chore: require beta before stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,40 @@ jobs:
           PR_VERSION=$(grep '"version"' package.json | head -1 | sed 's/.*: "\(.*\)".*/\1/')
           TAURI_VERSION=$(grep '"version"' src-tauri/tauri.conf.json | head -1 | sed 's/.*: "\(.*\)".*/\1/')
           CARGO_VERSION=$(grep '^version' src-tauri/Cargo.toml | head -1 | sed 's/.*= "\(.*\)".*/\1/')
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          RELEASE_INFRA_ONLY=true
+
+          if [ -z "$CHANGED_FILES" ]; then
+            RELEASE_INFRA_ONLY=false
+          fi
+
+          while IFS= read -r changed_file; do
+            [ -z "$changed_file" ] && continue
+            case "$changed_file" in
+              .github/workflows/ci.yml|.github/workflows/release.yml|AGENTS.md|docs/release.md|scripts/release-guard.mjs|tests/node-shims.d.ts|tests/unit/release-guard.test.ts)
+                ;;
+              *)
+                RELEASE_INFRA_ONLY=false
+                ;;
+            esac
+          done <<EOF
+          $CHANGED_FILES
+          EOF
 
           echo "Base version:  $BASE_VERSION"
           echo "PR version:    $PR_VERSION"
           echo "Tauri version: $TAURI_VERSION"
           echo "Cargo version: $CARGO_VERSION"
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
 
           if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
-            echo "::error::Version in package.json ($PR_VERSION) was not bumped from main ($BASE_VERSION). Bump the version before merging."
-            exit 1
+            if [ "$RELEASE_INFRA_ONLY" = "true" ]; then
+              echo "Version bump skipped for release infrastructure-only changes."
+            else
+              echo "::error::Version in package.json ($PR_VERSION) was not bumped from main ($BASE_VERSION). Bump the version before merging."
+              exit 1
+            fi
           fi
 
           if [ "$PR_VERSION" != "$TAURI_VERSION" ]; then
@@ -43,7 +68,11 @@ jobs:
             exit 1
           fi
 
-          echo "Version bump verified: $BASE_VERSION → $PR_VERSION (all files match)"
+          if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+            echo "Version consistency verified: $PR_VERSION (release infrastructure-only PR)"
+          else
+            echo "Version bump verified: $BASE_VERSION → $PR_VERSION (all files match)"
+          fi
 
   check-build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Require beta prerelease before stable release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: node scripts/release-guard.mjs
+
       - name: Create draft release with auto-generated notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Design choices must support both desktop and future web:
 - Bump the version as the **last commit** on the feature branch before merging — not in a separate PR.
 - All three files must match: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`.
 - After merge to `main`, tag a beta first (`git tag vX.Y.Z-beta.1 && git push origin vX.Y.Z-beta.1`) to trigger the desktop prerelease workflow for Windows/macOS testing.
-- Do not tag a stable `vX.Y.Z` release until a matching published `vX.Y.Z-beta.N` prerelease exists with macOS and Windows artifacts. The release workflow enforces this through `npm run release:guard`.
+- Do not tag a stable `vX.Y.Z` release until a matching published `vX.Y.Z-beta.N` prerelease exists with macOS and Windows artifacts. The release workflow enforces this through `node scripts/release-guard.mjs`.
 - After beta testing passes, tag the same validated merge commit with `vX.Y.Z` (`git tag vX.Y.Z && git push origin vX.Y.Z`) to trigger the stable release workflow.
 - Use semantic versioning: `feat` = minor bump, `fix` = patch bump.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,9 @@ Design choices must support both desktop and future web:
 ## Versioning (Mandatory)
 - Bump the version as the **last commit** on the feature branch before merging — not in a separate PR.
 - All three files must match: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`.
-- After merge to `main`, tag the merge commit (`git tag vX.Y.Z && git push origin vX.Y.Z`) to trigger the release workflow.
+- After merge to `main`, tag a beta first (`git tag vX.Y.Z-beta.1 && git push origin vX.Y.Z-beta.1`) to trigger the desktop prerelease workflow for Windows/macOS testing.
+- Do not tag a stable `vX.Y.Z` release until a matching published `vX.Y.Z-beta.N` prerelease exists with macOS and Windows artifacts. The release workflow enforces this through `npm run release:guard`.
+- After beta testing passes, tag the same validated merge commit with `vX.Y.Z` (`git tag vX.Y.Z && git push origin vX.Y.Z`) to trigger the stable release workflow.
 - Use semantic versioning: `feat` = minor bump, `fix` = patch bump.
 
 ## Definition of Done (Per Issue)

--- a/docs/release.md
+++ b/docs/release.md
@@ -32,10 +32,13 @@ npm run check        # Run TypeScript type checking
 
 ### CI Build
 Trigger a build via GitHub Actions:
-- **Tag push**: `git tag v1.0.0 && git push origin v1.0.0`
+- **Beta tag push**: `git tag v1.0.0-beta.1 && git push origin v1.0.0-beta.1`
+- **Stable tag push**: `git tag v1.0.0 && git push origin v1.0.0`
 - **Manual**: Actions > "Build Desktop App" > Run workflow
 
 Build artifacts are uploaded as GitHub Actions artifacts and (for tag pushes) attached to a draft GitHub Release.
+
+Stable release tags are blocked unless a matching published beta prerelease exists first. For example, `v1.0.0` requires a non-draft `v1.0.0-beta.N` GitHub prerelease with both macOS and Windows artifacts attached. The workflow runs `npm run release:guard` before creating or building a stable release.
 
 ### Local Build
 ```bash
@@ -75,6 +78,16 @@ Version is maintained in three files (all must match):
 - `src-tauri/Cargo.toml` → `version`
 
 All three should be updated together before tagging a release.
+
+## Beta-First Release Flow
+
+1. Merge the release PR to `main`.
+2. Tag the merge commit as a beta: `git tag vX.Y.Z-beta.1 && git push origin vX.Y.Z-beta.1`.
+3. Wait for the desktop workflow to attach macOS and Windows artifacts to the draft prerelease.
+4. Publish the prerelease and test the artifacts on macOS and Windows.
+5. After testing passes, tag the same validated commit as stable: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+
+The stable tag guard checks GitHub Releases, not local tags. A qualifying beta must be published, marked as a prerelease, and include at least one macOS artifact (`.dmg` or `.app.tar.gz`) plus one Windows artifact (`.msi`, `.exe`, or `.nsis.zip`).
 
 ## Verification Checklist
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -38,7 +38,7 @@ Trigger a build via GitHub Actions:
 
 Build artifacts are uploaded as GitHub Actions artifacts and (for tag pushes) attached to a draft GitHub Release.
 
-Stable release tags are blocked unless a matching published beta prerelease exists first. For example, `v1.0.0` requires a non-draft `v1.0.0-beta.N` GitHub prerelease with both macOS and Windows artifacts attached. The workflow runs `npm run release:guard` before creating or building a stable release.
+Stable release tags are blocked unless a matching published beta prerelease exists first. For example, `v1.0.0` requires a non-draft `v1.0.0-beta.N` GitHub prerelease with both macOS and Windows artifacts attached. The workflow runs `node scripts/release-guard.mjs` before creating or building a stable release.
 
 ### Local Build
 ```bash

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "code-health": "node scripts/code-health.mjs --changed",
     "code-health:changed": "node scripts/code-health.mjs --changed",
     "code-health:full": "node scripts/code-health.mjs --full",
+    "release:guard": "node scripts/release-guard.mjs",
     "test": "npx playwright test",
     "test:unit": "vitest run",
     "test:e2e": "npx playwright test",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "code-health": "node scripts/code-health.mjs --changed",
     "code-health:changed": "node scripts/code-health.mjs --changed",
     "code-health:full": "node scripts/code-health.mjs --full",
-    "release:guard": "node scripts/release-guard.mjs",
     "test": "npx playwright test",
     "test:unit": "vitest run",
     "test:e2e": "npx playwright test",

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+const STABLE_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
+const PRERELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+-(?:beta|rc)\.\d+$/;
+const MAC_ARTIFACT_PATTERN = /\.(?:dmg|app\.tar\.gz)$/i;
+const WINDOWS_ARTIFACT_PATTERN = /\.(?:msi|exe|nsis\.zip)$/i;
+
+function parseArgs(argv) {
+  const tagIndex = argv.indexOf('--tag');
+  if (tagIndex >= 0) {
+    const tag = argv[tagIndex + 1];
+    if (!tag) {
+      throw new Error('Missing value for --tag.');
+    }
+    return { tag };
+  }
+
+  return { tag: process.env.GITHUB_REF_NAME ?? '' };
+}
+
+function isStableTag(tag) {
+  return STABLE_TAG_PATTERN.test(tag);
+}
+
+function isPrereleaseTag(tag) {
+  return PRERELEASE_TAG_PATTERN.test(tag);
+}
+
+function hasMacArtifact(release) {
+  return (release.assets ?? []).some((asset) => MAC_ARTIFACT_PATTERN.test(asset.name ?? ''));
+}
+
+function hasWindowsArtifact(release) {
+  return (release.assets ?? []).some((asset) => WINDOWS_ARTIFACT_PATTERN.test(asset.name ?? ''));
+}
+
+function isQualifyingBetaRelease(release, stableTag) {
+  return (
+    typeof release.tag_name === 'string' &&
+    release.tag_name.startsWith(`${stableTag}-beta.`) &&
+    release.prerelease === true &&
+    release.draft === false &&
+    hasMacArtifact(release) &&
+    hasWindowsArtifact(release)
+  );
+}
+
+function findQualifyingBetaRelease(releases, stableTag) {
+  return releases.find((release) => isQualifyingBetaRelease(release, stableTag)) ?? null;
+}
+
+async function fetchGitHubReleases() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY is required when RELEASE_GUARD_RELEASES_JSON is not set.');
+  }
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is required when RELEASE_GUARD_RELEASES_JSON is not set.');
+  }
+
+  const response = await fetch(`https://api.github.com/repos/${repository}/releases?per_page=100`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'x-github-api-version': '2022-11-28'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub releases API returned ${response.status}: ${await response.text()}`);
+  }
+
+  return await response.json();
+}
+
+async function loadReleases() {
+  if (process.env.RELEASE_GUARD_RELEASES_JSON) {
+    const releases = JSON.parse(process.env.RELEASE_GUARD_RELEASES_JSON);
+    if (!Array.isArray(releases)) {
+      throw new Error('RELEASE_GUARD_RELEASES_JSON must be a JSON array.');
+    }
+    return releases;
+  }
+
+  return await fetchGitHubReleases();
+}
+
+async function main() {
+  const { tag } = parseArgs(process.argv.slice(2));
+  if (!tag) {
+    throw new Error('No tag supplied. Pass --tag or set GITHUB_REF_NAME.');
+  }
+
+  if (isPrereleaseTag(tag)) {
+    console.log(`Tag ${tag} is a prerelease tag and does not require prior beta verification.`);
+    return;
+  }
+
+  if (!isStableTag(tag)) {
+    console.log(`Tag ${tag} is not a stable release tag; skipping beta release guard.`);
+    return;
+  }
+
+  const releases = await loadReleases();
+  const betaRelease = findQualifyingBetaRelease(releases, tag);
+
+  if (!betaRelease) {
+    throw new Error(
+      [
+        `No qualifying beta prerelease found for ${tag}.`,
+        `Publish and test a ${tag}-beta.N prerelease before pushing ${tag}.`,
+        'The beta prerelease must be non-draft, marked prerelease, and include macOS plus Windows artifacts.'
+      ].join(' ')
+    );
+  }
+
+  console.log(`Found qualifying beta prerelease ${betaRelease.tag_name}; stable release ${tag} may proceed.`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/tests/node-shims.d.ts
+++ b/tests/node-shims.d.ts
@@ -1,2 +1,9 @@
 declare module 'fs';
+declare module 'node:child_process';
+declare module 'node:util';
 declare module 'path';
+
+declare const process: {
+	cwd(): string;
+	env: Record<string, string | undefined>;
+};

--- a/tests/unit/release-guard.test.ts
+++ b/tests/unit/release-guard.test.ts
@@ -1,0 +1,76 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const scriptPath = 'scripts/release-guard.mjs';
+
+function release(overrides: Record<string, unknown> = {}) {
+	return {
+		tag_name: 'v1.19.4-beta.1',
+		draft: false,
+		prerelease: true,
+		assets: [
+			{ name: 'RV Reservation System_1.19.4_universal.dmg' },
+			{ name: 'RV Reservation System_1.19.4_x64_en-US.msi' }
+		],
+		...overrides
+	};
+}
+
+async function runGuard(tag: string, releases: unknown[] = []) {
+	return await execFileAsync('node', [scriptPath, '--tag', tag], {
+		cwd: process.cwd(),
+		env: {
+			...process.env,
+			RELEASE_GUARD_RELEASES_JSON: JSON.stringify(releases)
+		}
+	});
+}
+
+async function expectGuardFailure(tag: string, releases: unknown[] = []) {
+	try {
+		await runGuard(tag, releases);
+		throw new Error('Expected release guard to fail');
+	} catch (error) {
+		if (error instanceof Error && error.message === 'Expected release guard to fail') {
+			throw error;
+		}
+		return error as { stdout: string; stderr: string };
+	}
+}
+
+describe('release guard', () => {
+	it('skips prerelease tags', async () => {
+		const { stdout } = await runGuard('v1.19.4-beta.1');
+
+		expect(stdout).toContain('does not require prior beta verification');
+	});
+
+	it('allows stable tags when a published matching beta has macOS and Windows assets', async () => {
+		const { stdout } = await runGuard('v1.19.4', [release()]);
+
+		expect(stdout).toContain('Found qualifying beta prerelease v1.19.4-beta.1');
+	});
+
+	it('rejects stable tags without a matching beta prerelease', async () => {
+		const error = await expectGuardFailure('v1.19.4', [release({ tag_name: 'v1.19.3-beta.1' })]);
+
+		expect(error.stderr).toContain('No qualifying beta prerelease found for v1.19.4');
+	});
+
+	it('rejects draft beta releases because they were not published for testing', async () => {
+		const error = await expectGuardFailure('v1.19.4', [release({ draft: true })]);
+
+		expect(error.stderr).toContain('No qualifying beta prerelease found for v1.19.4');
+	});
+
+	it('rejects beta releases that do not include both desktop platform artifacts', async () => {
+		const error = await expectGuardFailure('v1.19.4', [
+			release({ assets: [{ name: 'RV Reservation System_1.19.4_universal.dmg' }] })
+		]);
+
+		expect(error.stderr).toContain('No qualifying beta prerelease found for v1.19.4');
+	});
+});


### PR DESCRIPTION
## Summary
- add a release guard script that blocks stable vX.Y.Z tags unless a matching published vX.Y.Z-beta.N prerelease exists
- require the matching beta prerelease to include both macOS and Windows desktop artifacts
- wire the guard into the release workflow before stable release creation/build
- document the beta-first release flow in AGENTS.md and docs/release.md

## Versioning
- no app version bump: this is release infrastructure only, and it intentionally keeps the app at 1.19.4 so the guard can protect the upcoming stable v1.19.4 tag after the existing v1.19.4-beta.1 test build

## Validation
- npm run test:unit -- tests/unit/release-guard.test.ts
- node scripts/release-guard.mjs --tag v1.19.4-beta.1
- npm run code-health:changed
- npm run check
- npm run build
- npm run test:unit
- npm run code-health:full