### PR TITLE
feat: add manual verified auto backup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,19 @@ name: Build Desktop App
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing tag to build/release, such as v1.20.0-beta.1 or v1.20.0'
+        required: true
+        type: string
+      stable_release_consent:
+        description: 'For stable tags only, type exactly: I consent to publish stable release vX.Y.Z'
+        required: false
+        type: string
   push:
     tags:
-      - 'v*'
+      - 'v*-beta.*'
+      - 'v*-rc.*'
 
 # Signing: configure APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD,
 # APPLE_SIGNING_IDENTITY, APPLE_ID, APPLE_PASSWORD, APPLE_TEAM_ID
@@ -15,30 +25,41 @@ permissions:
 
 jobs:
   create-release:
-    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Validate release tag input
+        run: |
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "::error::Release tag is required."
+            exit 1
+          fi
 
       - name: Require beta prerelease before stable release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF_NAME: ${{ env.RELEASE_TAG }}
+          RELEASE_GUARD_STABLE_RELEASE_CONSENT: ${{ github.event_name == 'workflow_dispatch' && inputs.stable_release_consent || '' }}
         run: node scripts/release-guard.mjs
 
       - name: Create draft release with auto-generated notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "${{ github.ref_name }}" &>/dev/null; then
-            echo "Release ${{ github.ref_name }} already exists, skipping creation."
+          if gh release view "$RELEASE_TAG" &>/dev/null; then
+            echo "Release $RELEASE_TAG already exists, skipping creation."
           else
             PRERELEASE_FLAG=""
-            if [[ "${{ github.ref_name }}" == *"-beta"* ]] || [[ "${{ github.ref_name }}" == *"-rc"* ]]; then
+            if [[ "$RELEASE_TAG" == *"-beta"* ]] || [[ "$RELEASE_TAG" == *"-rc"* ]]; then
               PRERELEASE_FLAG="--prerelease"
             fi
-            gh release create "${{ github.ref_name }}" --draft --generate-notes $PRERELEASE_FLAG --title "RV Reservation System ${{ github.ref_name }}"
+            gh release create "$RELEASE_TAG" --draft --generate-notes $PRERELEASE_FLAG --title "RV Reservation System $RELEASE_TAG"
           fi
 
   build-tauri:
@@ -57,9 +78,13 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: actions/setup-node@v4
         with:
@@ -85,10 +110,10 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
-          releaseName: ${{ github.ref_type == 'tag' && format('RV Reservation System {0}', github.ref_name) || '' }}
+          tagName: ${{ env.RELEASE_TAG }}
+          releaseName: RV Reservation System ${{ env.RELEASE_TAG }}
           releaseDraft: true
-          prerelease: ${{ contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
+          prerelease: ${{ contains(env.RELEASE_TAG, '-beta') || contains(env.RELEASE_TAG, '-rc') }}
           includeUpdaterJson: true
           args: ${{ matrix.args }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,8 +136,9 @@ Design choices must support both desktop and future web:
 - Bump the version as the **last commit** on the feature branch before merging — not in a separate PR.
 - All three files must match: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`.
 - After merge to `main`, tag a beta first (`git tag vX.Y.Z-beta.1 && git push origin vX.Y.Z-beta.1`) to trigger the desktop prerelease workflow for Windows/macOS testing.
-- Do not tag a stable `vX.Y.Z` release until a matching published `vX.Y.Z-beta.N` prerelease exists with macOS and Windows artifacts. The release workflow enforces this through `node scripts/release-guard.mjs`.
-- After beta testing passes, tag the same validated merge commit with `vX.Y.Z` (`git tag vX.Y.Z && git push origin vX.Y.Z`) to trigger the stable release workflow.
+- Do not tag a stable `vX.Y.Z` release until a matching published `vX.Y.Z-beta.N` prerelease exists with macOS and Windows artifacts.
+- After beta testing passes, tag the same validated merge commit with `vX.Y.Z` (`git tag vX.Y.Z && git push origin vX.Y.Z`). Stable tag pushes are intentionally inert for the release workflow.
+- Stable releases require manual workflow dispatch plus exact tag-specific consent: `I consent to publish stable release vX.Y.Z`. The release workflow enforces this through `node scripts/release-guard.mjs`.
 - Use semantic versioning: `feat` = minor bump, `fix` = patch bump.
 
 ## Definition of Done (Per Issue)

--- a/docs/release.md
+++ b/docs/release.md
@@ -33,12 +33,17 @@ npm run check        # Run TypeScript type checking
 ### CI Build
 Trigger a build via GitHub Actions:
 - **Beta tag push**: `git tag v1.0.0-beta.1 && git push origin v1.0.0-beta.1`
-- **Stable tag push**: `git tag v1.0.0 && git push origin v1.0.0`
-- **Manual**: Actions > "Build Desktop App" > Run workflow
+- **RC tag push**: `git tag v1.0.0-rc.1 && git push origin v1.0.0-rc.1`
+- **Stable release**: Actions > "Build Desktop App" > Run workflow, enter the existing stable tag, and type the exact consent phrase shown below.
 
-Build artifacts are uploaded as GitHub Actions artifacts and (for tag pushes) attached to a draft GitHub Release.
+Build artifacts are uploaded as GitHub Actions artifacts and attached to a draft GitHub Release.
 
-Stable release tags are blocked unless a matching published beta prerelease exists first. For example, `v1.0.0` requires a non-draft `v1.0.0-beta.N` GitHub prerelease with both macOS and Windows artifacts attached. The workflow runs `node scripts/release-guard.mjs` before creating or building a stable release.
+Stable release tag pushes do not trigger the release workflow. Stable releases are blocked unless both of these conditions are true:
+
+- A matching published beta prerelease exists first. For example, `v1.0.0` requires a non-draft `v1.0.0-beta.N` GitHub prerelease with both macOS and Windows artifacts attached.
+- The manual workflow input `stable_release_consent` exactly matches `I consent to publish stable release v1.0.0`, with the target stable tag substituted.
+
+The workflow runs `node scripts/release-guard.mjs` before creating or building any release. Unsupported release tag formats are rejected.
 
 ### Local Build
 ```bash
@@ -85,9 +90,10 @@ All three should be updated together before tagging a release.
 2. Tag the merge commit as a beta: `git tag vX.Y.Z-beta.1 && git push origin vX.Y.Z-beta.1`.
 3. Wait for the desktop workflow to attach macOS and Windows artifacts to the draft prerelease.
 4. Publish the prerelease and test the artifacts on macOS and Windows.
-5. After testing passes, tag the same validated commit as stable: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+5. After testing passes, tag the same validated commit as stable: `git tag vX.Y.Z && git push origin vX.Y.Z`. This tag push is intentionally inert for the release workflow.
+6. In GitHub Actions, run "Build Desktop App" manually with `release_tag` set to `vX.Y.Z` and `stable_release_consent` set exactly to `I consent to publish stable release vX.Y.Z`.
 
-The stable tag guard checks GitHub Releases, not local tags. A qualifying beta must be published, marked as a prerelease, and include at least one macOS artifact (`.dmg` or `.app.tar.gz`) plus one Windows artifact (`.msi`, `.exe`, or `.nsis.zip`).
+The stable tag guard checks GitHub Releases, not local tags. A qualifying beta must be published, marked as a prerelease, and include at least one macOS artifact (`.dmg` or `.app.tar.gz`) plus one Windows artifact (`.msi`, `.exe`, or `.nsis.zip`). The consent guard is exact and tag-specific, so consent for one stable version cannot accidentally authorize another.
 
 ## Verification Checklist
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.4",
+  "version": "1.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rv-reservation-system",
-      "version": "1.19.4",
+      "version": "1.20.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rv-reservation-system",
-  "version": "1.19.4",
+  "version": "1.20.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
 		}
 	],
 	webServer: {
-		command: 'npm run build && npm run preview -- --port 4173',
+		command: 'npm run build -- --mode test && npm run preview -- --port 4173',
 		port: 4173,
 		reuseExistingServer: !process.env.CI,
 		timeout: 60_000

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -4,6 +4,7 @@ const STABLE_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
 const PRERELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+-(?:beta|rc)\.\d+$/;
 const MAC_ARTIFACT_PATTERN = /\.(?:dmg|app\.tar\.gz)$/i;
 const WINDOWS_ARTIFACT_PATTERN = /\.(?:msi|exe|nsis\.zip)$/i;
+const STABLE_RELEASE_CONSENT_ENV = 'RELEASE_GUARD_STABLE_RELEASE_CONSENT';
 
 function parseArgs(argv) {
   const tagIndex = argv.indexOf('--tag');
@@ -24,6 +25,26 @@ function isStableTag(tag) {
 
 function isPrereleaseTag(tag) {
   return PRERELEASE_TAG_PATTERN.test(tag);
+}
+
+function expectedStableReleaseConsent(tag) {
+  return `I consent to publish stable release ${tag}`;
+}
+
+function requireStableReleaseConsent(tag) {
+  const expectedConsent = expectedStableReleaseConsent(tag);
+  const suppliedConsent = process.env[STABLE_RELEASE_CONSENT_ENV] ?? '';
+
+  if (suppliedConsent !== expectedConsent) {
+    throw new Error(
+      [
+        `Explicit consent is required before publishing stable release ${tag}.`,
+        `Set ${STABLE_RELEASE_CONSENT_ENV} exactly to: ${expectedConsent}`
+      ].join(' ')
+    );
+  }
+
+  console.log(`Stable release consent verified for ${tag}.`);
 }
 
 function hasMacArtifact(release) {
@@ -99,9 +120,12 @@ async function main() {
   }
 
   if (!isStableTag(tag)) {
-    console.log(`Tag ${tag} is not a stable release tag; skipping beta release guard.`);
-    return;
+    throw new Error(
+      `Unsupported release tag ${tag}. Use vX.Y.Z for stable releases or vX.Y.Z-beta.N / vX.Y.Z-rc.N for prereleases.`
+    );
   }
+
+  requireStableReleaseConsent(tag);
 
   const releases = await loadReleases();
   const betaRelease = findQualifyingBetaRelease(releases, tag);

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rv-reservation-system"
-version = "1.19.4"
+version = "1.20.0"
 description = "RV Reservation Schedule"
 authors = ["Nostos Labs"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "RV Reservation System",
-  "version": "1.19.4",
+  "version": "1.20.0",
   "identifier": "com.nostoslabs.rv-reservation-system",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/app/auto-backup.ts
+++ b/src/lib/app/auto-backup.ts
@@ -1,6 +1,6 @@
 import type { AutoBackupConfig } from '$lib/types';
 import type { DesktopCapabilities } from '$lib/application/ports';
-import { generateBackupFilename } from '$lib/domain/backup';
+import { writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
 import { writable } from 'svelte/store';
 
 export interface BackupStatus {
@@ -14,6 +14,18 @@ export const backupStatus = writable<BackupStatus>({
 	lastErrorAt: null,
 	consecutiveFailures: 0
 });
+
+export function clearBackupStatus(): void {
+	backupStatus.set({ lastError: null, lastErrorAt: null, consecutiveFailures: 0 });
+}
+
+export function recordBackupError(error: unknown): void {
+	backupStatus.update((s) => ({
+		lastError: error instanceof Error ? error.message : String(error),
+		lastErrorAt: new Date().toISOString(),
+		consecutiveFailures: s.consecutiveFailures + 1
+	}));
+}
 
 export interface AutoBackupDeps {
 	getConfig: () => AutoBackupConfig;
@@ -41,20 +53,20 @@ export function startAutoBackupTimer(deps: AutoBackupDeps): () => void {
 
 		running = true;
 		try {
-			const content = deps.getBackupContent();
-			const filename = generateBackupFilename();
-			const separator = config.directoryPath!.endsWith('/') || config.directoryPath!.endsWith('\\') ? '' : '/';
-			const filePath = `${config.directoryPath}${separator}${filename}`;
-			await deps.desktop.writeFileToPath(filePath, content);
-			await deps.onSuccess(new Date().toISOString());
-			backupStatus.set({ lastError: null, lastErrorAt: null, consecutiveFailures: 0 });
+			const result = await writeVerifiedBackupToDirectory({
+				desktop: deps.desktop,
+				directoryPath: config.directoryPath!,
+				getBackupContent: deps.getBackupContent
+			});
+			if (!result.ok) {
+				throw new Error(result.error);
+			}
+
+			await deps.onSuccess(result.timestamp);
+			clearBackupStatus();
 		} catch (error) {
 			deps.onError(error);
-			backupStatus.update((s) => ({
-				lastError: error instanceof Error ? error.message : String(error),
-				lastErrorAt: new Date().toISOString(),
-				consecutiveFailures: s.consecutiveFailures + 1
-			}));
+			recordBackupError(error);
 		} finally {
 			running = false;
 		}

--- a/src/lib/app/auto-backup.ts
+++ b/src/lib/app/auto-backup.ts
@@ -46,6 +46,13 @@ export interface ManualBackupDeps {
 	onSuccess: (timestamp: string) => Promise<{ ok: boolean; errors?: string[] }>;
 }
 
+export interface BackupOnExitDeps {
+	desktop: DesktopCapabilities;
+	getConfig: () => AutoBackupConfig;
+	getBackupContent: () => string;
+	onSuccess: (timestamp: string) => Promise<{ ok: boolean; errors?: string[] }>;
+}
+
 export function isBackupDue(config: AutoBackupConfig): boolean {
 	if (config.intervalMinutes <= 0 || !config.directoryPath) return false;
 	if (!config.lastBackupAt) return true;
@@ -81,6 +88,34 @@ export async function runManualBackupNow(deps: ManualBackupDeps): Promise<Manual
 		const message = formatBackupError(error);
 		recordBackupError(message);
 		return { ok: false, error: message };
+	}
+}
+
+export async function runBackupOnExit(deps: BackupOnExitDeps): Promise<void> {
+	try {
+		const config = deps.getConfig();
+		if (!config.directoryPath) return;
+
+		const result = await writeVerifiedBackupToDirectory({
+			desktop: deps.desktop,
+			directoryPath: config.directoryPath,
+			getBackupContent: deps.getBackupContent
+		});
+
+		if (!result.ok) {
+			recordBackupError(result.error);
+			return;
+		}
+
+		const recorded = await deps.onSuccess(result.timestamp);
+		if (!recorded.ok) {
+			recordBackupError(recorded.errors?.[0] ?? 'Exit backup timestamp could not be saved.');
+			return;
+		}
+
+		clearBackupStatus();
+	} catch (error) {
+		recordBackupError(formatBackupError(error));
 	}
 }
 

--- a/src/lib/app/auto-backup.ts
+++ b/src/lib/app/auto-backup.ts
@@ -1,6 +1,6 @@
 import type { AutoBackupConfig } from '$lib/types';
 import type { DesktopCapabilities } from '$lib/application/ports';
-import { writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
+import { formatBackupError, writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
 import { writable } from 'svelte/store';
 
 export interface BackupStatus {
@@ -35,11 +35,53 @@ export interface AutoBackupDeps {
 	onError: (error: unknown) => void;
 }
 
+export type ManualBackupResult =
+	| { ok: true }
+	| { ok: false; error: string };
+
+export interface ManualBackupDeps {
+	desktop: DesktopCapabilities;
+	directoryPath: string;
+	getBackupContent: () => string;
+	onSuccess: (timestamp: string) => Promise<{ ok: boolean; errors?: string[] }>;
+}
+
 export function isBackupDue(config: AutoBackupConfig): boolean {
 	if (config.intervalMinutes <= 0 || !config.directoryPath) return false;
 	if (!config.lastBackupAt) return true;
 	const elapsed = Date.now() - new Date(config.lastBackupAt).getTime();
 	return elapsed >= config.intervalMinutes * 60_000;
+}
+
+export async function runManualBackupNow(deps: ManualBackupDeps): Promise<ManualBackupResult> {
+	try {
+		const result = await writeVerifiedBackupToDirectory({
+			desktop: deps.desktop,
+			directoryPath: deps.directoryPath,
+			getBackupContent: deps.getBackupContent
+		});
+
+		if (!result.ok) {
+			recordBackupError(result.error);
+			return result;
+		}
+
+		const recorded = await deps.onSuccess(result.timestamp);
+		if (!recorded.ok) {
+			clearBackupStatus();
+			return {
+				ok: false,
+				error: recorded.errors?.[0] ?? 'Backup was created, but the timestamp could not be saved.'
+			};
+		}
+
+		clearBackupStatus();
+		return { ok: true };
+	} catch (error) {
+		const message = formatBackupError(error);
+		recordBackupError(message);
+		return { ok: false, error: message };
+	}
 }
 
 export function startAutoBackupTimer(deps: AutoBackupDeps): () => void {

--- a/src/lib/app/backup-content.ts
+++ b/src/lib/app/backup-content.ts
@@ -1,0 +1,13 @@
+import { get } from 'svelte/store';
+import { createBackup } from '$lib/domain/backup';
+import { customerStore } from '$lib/customer-state';
+import { rvReservationStore } from '$lib/state';
+import { siteSettingsStore } from '$lib/site-settings';
+
+export function createCurrentBackupContent(): string {
+	const state = get(rvReservationStore);
+	const settings = get(siteSettingsStore);
+	const customers = customerStore.getAll();
+	const backup = createBackup(state.reservations, state.parkingLocations, settings, customers);
+	return JSON.stringify(backup, null, 2);
+}

--- a/src/lib/app/composition.ts
+++ b/src/lib/app/composition.ts
@@ -16,6 +16,12 @@ import { createLocalStorageAppDataRepository } from '$lib/infrastructure/storage
 import { createLocalStorageSiteSettingsRepository } from '$lib/infrastructure/storage/localstorage/site-settings-repository';
 import { createLocalStorageCustomerRepository } from '$lib/infrastructure/storage/localstorage/customer-repository';
 
+declare global {
+	interface Window {
+		__RV_TEST_DESKTOP_CAPABILITIES__?: Partial<DesktopCapabilities> & { isDesktop?: boolean };
+	}
+}
+
 export interface AppServices {
 	desktop: DesktopCapabilities;
 	repositories: StorageRepositories;
@@ -35,6 +41,18 @@ function isTauri(): boolean {
 	return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 }
 
+function createBrowserDesktopCapabilities(): DesktopCapabilities {
+	const fallback = createWebFallbackDesktopCapabilities();
+	const testOverride = typeof window !== 'undefined' ? window.__RV_TEST_DESKTOP_CAPABILITIES__ : undefined;
+	if (!testOverride) return fallback;
+
+	return {
+		...fallback,
+		...testOverride,
+		isDesktop: testOverride.isDesktop ?? true
+	};
+}
+
 function createLocalStorageServices(): AppServices {
 	flushFn = null;
 	const appDataRepo = createLocalStorageAppDataRepository();
@@ -48,7 +66,7 @@ function createLocalStorageServices(): AppServices {
 	};
 
 	return {
-		desktop: createWebFallbackDesktopCapabilities(),
+		desktop: createBrowserDesktopCapabilities(),
 		repositories,
 		reservationUseCases: createReservationUseCases(appDataRepo),
 		parkingLocationUseCases: createParkingLocationUseCases(appDataRepo),

--- a/src/lib/app/composition.ts
+++ b/src/lib/app/composition.ts
@@ -43,7 +43,10 @@ function isTauri(): boolean {
 
 function createBrowserDesktopCapabilities(): DesktopCapabilities {
 	const fallback = createWebFallbackDesktopCapabilities();
-	const testOverride = typeof window !== 'undefined' ? window.__RV_TEST_DESKTOP_CAPABILITIES__ : undefined;
+	const testOverride =
+		import.meta.env.MODE === 'test' && typeof window !== 'undefined'
+			? window.__RV_TEST_DESKTOP_CAPABILITIES__
+			: undefined;
 	if (!testOverride) return fallback;
 
 	return {

--- a/src/lib/app/composition.ts
+++ b/src/lib/app/composition.ts
@@ -1,4 +1,6 @@
 import type { DesktopCapabilities, StorageRepositories } from '$lib/application/ports';
+import { createBackup } from '$lib/domain/backup';
+import { runBackupOnExit } from '$lib/app/auto-backup';
 import {
 	createReservationUseCases,
 	createParkingLocationUseCases,
@@ -189,6 +191,45 @@ export async function flushPendingWrites(): Promise<void> {
 	if (flushFn) await flushFn();
 }
 
+async function runConfiguredBackupOnExit(): Promise<void> {
+	if (!instance) return;
+
+	const services = instance;
+	await runBackupOnExit({
+		desktop: services.desktop,
+		getConfig: () =>
+			services.repositories.siteSettings.load().autoBackup ?? {
+				intervalMinutes: 0,
+				directoryPath: null,
+				lastBackupAt: null
+			},
+		getBackupContent: () => {
+			const appData = services.repositories.appData.load();
+			const settings = services.repositories.siteSettings.load();
+			const customers = services.repositories.customers.getAll();
+			return JSON.stringify(
+				createBackup(appData.reservations, appData.parkingLocations, settings, customers),
+				null,
+				2
+			);
+		},
+		onSuccess: async (timestamp) => {
+			const settings = services.repositories.siteSettings.load();
+			const autoBackup = settings.autoBackup;
+			if (!autoBackup?.directoryPath) return { ok: true };
+
+			services.repositories.siteSettings.save({
+				...settings,
+				autoBackup: {
+					...autoBackup,
+					lastBackupAt: timestamp
+				}
+			});
+			return { ok: true };
+		}
+	});
+}
+
 export async function registerPersistenceLifecycleHandlers(): Promise<() => void> {
 	if (typeof window === 'undefined') {
 		return () => {};
@@ -227,6 +268,8 @@ export async function registerPersistenceLifecycleHandlers(): Promise<() => void
 				event.preventDefault();
 
 				try {
+					await flushPendingWrites();
+					await runConfiguredBackupOnExit();
 					await flushPendingWrites();
 				} finally {
 					if (closeCleanup) {

--- a/src/lib/app/forced-backup.ts
+++ b/src/lib/app/forced-backup.ts
@@ -1,5 +1,6 @@
 import type { DesktopCapabilities } from '$lib/application/ports';
 import { generateBackupFilename } from '$lib/domain/backup';
+import { writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
 
 export const JSON_BACKUP_FILTERS = [{ name: 'JSON', extensions: ['json'] }];
 
@@ -14,31 +15,32 @@ export interface ForcedBackupDeps {
 	onSuccess?: (timestamp: string) => Promise<void>;
 }
 
-function joinBackupPath(directoryPath: string, filename: string): string {
-	const separator = directoryPath.endsWith('/') || directoryPath.endsWith('\\') ? '' : '/';
-	return `${directoryPath}${separator}${filename}`;
-}
-
 function formatBackupError(error: unknown): string {
 	return `Backup failed: ${error instanceof Error ? error.message : String(error)}`;
 }
 
 export async function createForcedBackup(deps: ForcedBackupDeps): Promise<ForcedBackupResult> {
-	const filename = generateBackupFilename();
 	const content = deps.getBackupContent();
 	const directoryPath = deps.getAutoBackupDirectory();
 
 	try {
 		if (directoryPath) {
-			await deps.desktop.writeFileToPath(joinBackupPath(directoryPath, filename), content);
+			const result = await writeVerifiedBackupToDirectory({
+				desktop: deps.desktop,
+				directoryPath,
+				getBackupContent: () => content
+			});
+			if (!result.ok) return result;
+			await deps.onSuccess?.(result.timestamp);
 		} else {
+			const filename = generateBackupFilename();
 			const saved = await deps.desktop.saveFile(filename, content, JSON_BACKUP_FILTERS);
 			if (!saved) {
 				return { ok: false, error: 'Update blocked because backup was not saved.' };
 			}
+			await deps.onSuccess?.(new Date().toISOString());
 		}
 
-		await deps.onSuccess?.(new Date().toISOString());
 		return { ok: true };
 	} catch (error) {
 		return { ok: false, error: formatBackupError(error) };

--- a/src/lib/app/forced-backup.ts
+++ b/src/lib/app/forced-backup.ts
@@ -1,6 +1,6 @@
 import type { DesktopCapabilities } from '$lib/application/ports';
 import { generateBackupFilename } from '$lib/domain/backup';
-import { writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
+import { formatBackupError, writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
 
 export const JSON_BACKUP_FILTERS = [{ name: 'JSON', extensions: ['json'] }];
 
@@ -13,10 +13,6 @@ export interface ForcedBackupDeps {
 	getBackupContent: () => string;
 	getAutoBackupDirectory: () => string | null | undefined;
 	onSuccess?: (timestamp: string) => Promise<void>;
-}
-
-function formatBackupError(error: unknown): string {
-	return `Backup failed: ${error instanceof Error ? error.message : String(error)}`;
 }
 
 export async function createForcedBackup(deps: ForcedBackupDeps): Promise<ForcedBackupResult> {

--- a/src/lib/app/undoable-actions.ts
+++ b/src/lib/app/undoable-actions.ts
@@ -16,6 +16,7 @@ export async function deleteReservationWithUndo(index: number): Promise<Mutation
 		index: reservation.index,
 		name: reservation.name,
 		rvType: reservation.rvType,
+		eta: reservation.eta,
 		phoneNumber: reservation.phoneNumber,
 		notes: reservation.notes,
 		startDate: reservation.startDate,
@@ -23,6 +24,7 @@ export async function deleteReservationWithUndo(index: number): Promise<Mutation
 		parkingLocation: reservation.parkingLocation,
 		color: reservation.color,
 		status: reservation.status,
+		createdAt: reservation.createdAt,
 		customerId: reservation.customerId
 	};
 
@@ -51,6 +53,7 @@ export async function saveReservationWithUndo(formInput: ReservationFormValues):
 		index: existing.index,
 		name: existing.name,
 		rvType: existing.rvType,
+		eta: existing.eta,
 		phoneNumber: existing.phoneNumber,
 		notes: existing.notes,
 		startDate: existing.startDate,
@@ -58,6 +61,7 @@ export async function saveReservationWithUndo(formInput: ReservationFormValues):
 		parkingLocation: existing.parkingLocation,
 		color: existing.color,
 		status: existing.status,
+		createdAt: existing.createdAt,
 		customerId: existing.customerId
 	};
 

--- a/src/lib/app/verified-backup.ts
+++ b/src/lib/app/verified-backup.ts
@@ -1,0 +1,46 @@
+import type { DesktopCapabilities } from '$lib/application/ports';
+import { generateBackupFilename } from '$lib/domain/backup';
+
+export type VerifiedBackupResult =
+	| { ok: true; filePath: string; timestamp: string }
+	| { ok: false; error: string };
+
+export interface VerifiedBackupDeps {
+	desktop: DesktopCapabilities;
+	directoryPath: string;
+	getBackupContent: () => string;
+	now?: () => Date;
+}
+
+function joinBackupPath(directoryPath: string, filename: string): string {
+	const separator = directoryPath.endsWith('/') || directoryPath.endsWith('\\') ? '' : '/';
+	return `${directoryPath}${separator}${filename}`;
+}
+
+function formatBackupError(error: unknown): string {
+	return `Backup failed: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+export async function writeVerifiedBackupToDirectory(deps: VerifiedBackupDeps): Promise<VerifiedBackupResult> {
+	try {
+		const content = deps.getBackupContent();
+		const filePath = joinBackupPath(deps.directoryPath, generateBackupFilename());
+
+		await deps.desktop.writeFileToPath(filePath, content);
+		const writtenContent = await deps.desktop.readFileFromPath(filePath);
+		if (writtenContent !== content) {
+			return {
+				ok: false,
+				error: 'Backup verification failed: written file contents did not match generated backup.'
+			};
+		}
+
+		return {
+			ok: true,
+			filePath,
+			timestamp: (deps.now?.() ?? new Date()).toISOString()
+		};
+	} catch (error) {
+		return { ok: false, error: formatBackupError(error) };
+	}
+}

--- a/src/lib/app/verified-backup.ts
+++ b/src/lib/app/verified-backup.ts
@@ -2,7 +2,7 @@ import type { DesktopCapabilities } from '$lib/application/ports';
 import { generateBackupFilename } from '$lib/domain/backup';
 
 export type VerifiedBackupResult =
-	| { ok: true; filePath: string; timestamp: string }
+	| { ok: true; timestamp: string }
 	| { ok: false; error: string };
 
 export interface VerifiedBackupDeps {
@@ -17,7 +17,7 @@ function joinBackupPath(directoryPath: string, filename: string): string {
 	return `${directoryPath}${separator}${filename}`;
 }
 
-function formatBackupError(error: unknown): string {
+export function formatBackupError(error: unknown): string {
 	return `Backup failed: ${error instanceof Error ? error.message : String(error)}`;
 }
 
@@ -37,7 +37,6 @@ export async function writeVerifiedBackupToDirectory(deps: VerifiedBackupDeps): 
 
 		return {
 			ok: true,
-			filePath,
 			timestamp: (deps.now?.() ?? new Date()).toISOString()
 		};
 	} catch (error) {

--- a/src/lib/application/ports/desktop.ts
+++ b/src/lib/application/ports/desktop.ts
@@ -38,6 +38,9 @@ export interface DesktopCapabilities {
 	/** Write content to a file path without showing a dialog (for background auto-backup). */
 	writeFileToPath(filePath: string, content: string): Promise<void>;
 
+	/** Read content from a file path without showing a dialog (for backup write verification). */
+	readFileFromPath(filePath: string): Promise<string>;
+
 	/** Show a native folder picker. Returns the selected directory path or null if cancelled. */
 	pickDirectory(): Promise<string | null>;
 

--- a/src/lib/application/use-cases/reservation-use-cases.ts
+++ b/src/lib/application/use-cases/reservation-use-cases.ts
@@ -4,6 +4,7 @@ import { addDays, diffDays } from '$lib/date';
 import {
 	buildFirstCellId,
 	checkOverlap,
+	normalizeEta,
 	normalizeName,
 	normalizePhoneNumber,
 	normalizeReservationNotes,
@@ -34,6 +35,7 @@ export function createReservationUseCases(_repo: AppDataRepository): Reservation
 			const form: ReservationFormValues = {
 				...formInput,
 				name: normalizeName(formInput.name),
+				eta: normalizeEta(formInput.eta ?? ''),
 				phoneNumber: normalizePhoneNumber(formInput.phoneNumber ?? ''),
 				notes: normalizeReservationNotes(formInput.notes ?? '')
 			};
@@ -58,6 +60,7 @@ export function createReservationUseCases(_repo: AppDataRepository): Reservation
 				firstCellId: buildFirstCellId(form.parkingLocation, form.startDate),
 				name: form.name,
 				rvType: (form.rvType ?? '').trim(),
+				eta: form.eta ?? '',
 				phoneNumber: form.phoneNumber,
 				notes: form.notes,
 				startDate: form.startDate,
@@ -65,6 +68,7 @@ export function createReservationUseCases(_repo: AppDataRepository): Reservation
 				parkingLocation: form.parkingLocation,
 				color: form.color,
 				status: form.status,
+				createdAt: existing?.createdAt ?? form.createdAt ?? new Date().toISOString(),
 				customerId: form.customerId
 			};
 

--- a/src/lib/components/ReservationModal.svelte
+++ b/src/lib/components/ReservationModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher, afterUpdate } from 'svelte';
-  import { addDays, compareIsoDates, diffDays } from '$lib/date';
+  import { addDays, compareIsoDates, diffDays, formatReservationDetail } from '$lib/date';
   import { MAX_RESERVATION_NOTES_LENGTH } from '$lib/reservations';
   import { STATUS_LABELS, getStatusSwatchStyle } from '$lib/domain/reservations/status';
   import { RESERVATION_STATUSES, type Reservation, type ReservationFormValues, type ReservationStatus } from '$lib/types';
@@ -17,6 +17,7 @@
   export let draft: ReservationFormValues = {
     name: '',
     rvType: '',
+    eta: '',
     phoneNumber: '',
     notes: '',
     startDate: '',
@@ -36,7 +37,7 @@
     bookagain: ReservationFormValues;
   }>();
 
-  const emptyExtras = { phoneNumber: '', rvType: '', notes: '' };
+  const emptyExtras = { phoneNumber: '', rvType: '', eta: '', notes: '' };
   let form: ReservationFormValues = { ...emptyExtras, ...draft };
   let confirmingDelete = false;
   let autocompleteRef: AutocompleteInput;
@@ -149,6 +150,7 @@
     dispatch('bookagain', {
       name: form.name,
       rvType: form.rvType,
+      eta: '',
       phoneNumber: form.phoneNumber,
       notes: form.notes,
       parkingLocation: form.parkingLocation,
@@ -158,6 +160,11 @@
       endDate: '',
       customerId: form.customerId
     });
+  }
+
+  function formatCreatedAt(value?: string): string {
+    if (!value) return '';
+    return formatReservationDetail(value.slice(0, 10));
   }
 </script>
 
@@ -171,6 +178,9 @@
           <h2 id="reservation-modal-title">{mode === 'create' ? 'New Reservation' : 'Edit Reservation'}</h2>
           {#if mode === 'edit' && typeof form.index === 'number'}
             <p class="meta">Reservation #{form.index}</p>
+          {/if}
+          {#if mode === 'edit' && form.createdAt}
+            <p class="meta" data-testid="reservation-created-at">Created {formatCreatedAt(form.createdAt)}</p>
           {/if}
         </div>
         <button
@@ -240,6 +250,11 @@
             <label>
               <span>RV Type</span>
               <input bind:value={form.rvType} type="text" placeholder="e.g. Fifth Wheel, Class A" maxlength="60" data-testid="rv-type-input" />
+            </label>
+
+            <label>
+              <span>ETA</span>
+              <input bind:value={form.eta} type="text" placeholder="e.g. 2 PM" maxlength="60" data-testid="reservation-eta-input" />
             </label>
 
             <label>

--- a/src/lib/domain/reservations/active-count.ts
+++ b/src/lib/domain/reservations/active-count.ts
@@ -1,0 +1,10 @@
+import { compareIsoDates } from '$lib/date';
+import type { Reservation } from '$lib/domain/models';
+
+export function countCurrentAndFutureReservations(
+	reservations: Reservation[],
+	todayIso: string
+): number {
+	return reservations.filter((reservation) => compareIsoDates(reservation.endDate, todayIso) >= 0)
+		.length;
+}

--- a/src/lib/domain/reservations/index.ts
+++ b/src/lib/domain/reservations/index.ts
@@ -1,8 +1,11 @@
 export { computeDailySummary } from './daily-summary';
 export type { DailySummary } from './daily-summary';
 
+export { countCurrentAndFutureReservations } from './active-count';
+
 export {
 	MAX_RESERVATION_NOTES_LENGTH,
+	normalizeEta,
 	normalizeName,
 	normalizePhoneNumber,
 	normalizeReservationNotes,

--- a/src/lib/domain/reservations/normalization.ts
+++ b/src/lib/domain/reservations/normalization.ts
@@ -8,6 +8,10 @@ export function normalizePhoneNumber(value: string): string {
 	return value.trim().replace(/\s+/g, ' ');
 }
 
+export function normalizeEta(value: string): string {
+	return value.trim().replace(/\s+/g, ' ');
+}
+
 export function normalizeReservationNotes(value: string): string {
 	return value.replace(/\r\n?/g, '\n').trim();
 }

--- a/src/lib/infrastructure/desktop/tauri-capabilities.ts
+++ b/src/lib/infrastructure/desktop/tauri-capabilities.ts
@@ -55,6 +55,10 @@ export function createTauriDesktopCapabilities(): DesktopCapabilities {
 			const { writeTextFile } = await import('@tauri-apps/plugin-fs');
 			await writeTextFile(filePath, content);
 		},
+		async readFileFromPath(filePath: string): Promise<string> {
+			const { readTextFile } = await import('@tauri-apps/plugin-fs');
+			return await readTextFile(filePath);
+		},
 		async pickDirectory(): Promise<string | null> {
 			const { open } = await import('@tauri-apps/plugin-dialog');
 			const path = await open({ multiple: false, directory: true });

--- a/src/lib/infrastructure/desktop/web-fallback.ts
+++ b/src/lib/infrastructure/desktop/web-fallback.ts
@@ -29,6 +29,9 @@ export function createWebFallbackDesktopCapabilities(): DesktopCapabilities {
 		async writeFileToPath(): Promise<void> {
 			// No-op in web — auto-backup is desktop-only
 		},
+		async readFileFromPath(): Promise<string> {
+			throw new Error('Reading files by path is only available in the desktop app.');
+		},
 		async pickDirectory(): Promise<string | null> {
 			return null;
 		},

--- a/src/lib/infrastructure/storage/sqlite/app-data-repository.ts
+++ b/src/lib/infrastructure/storage/sqlite/app-data-repository.ts
@@ -11,6 +11,7 @@ interface ReservationRow {
 	id: number;
 	name: string;
 	rv_type: string;
+	eta: string;
 	phone_number: string;
 	notes: string;
 	start_date: string;
@@ -18,6 +19,7 @@ interface ReservationRow {
 	parking_location: string;
 	color: string;
 	status: string | null;
+	created_at: string | null;
 	customer_id: string | null;
 }
 
@@ -52,13 +54,15 @@ function rowToReservation(row: ReservationRow): Reservation {
 		firstCellId: buildFirstCellId(row.parking_location, row.start_date),
 		name: row.name,
 		rvType: row.rv_type ?? '',
+		eta: row.eta ?? '',
 		phoneNumber: row.phone_number,
 		notes: row.notes,
 		startDate: row.start_date,
 		endDate: row.end_date,
 		parkingLocation: row.parking_location,
 		color: row.color as ReservationColor,
-		status
+		status,
+		createdAt: row.created_at || row.start_date
 	};
 
 	if (row.customer_id) {
@@ -122,8 +126,22 @@ async function saveToDb(db: Database, data: PersistedAppData): Promise<number> {
 		// Re-insert reservations (parking_locations rows exist now)
 		for (const r of data.reservations) {
 			await db.execute(
-				'INSERT INTO reservations (id, name, rv_type, phone_number, notes, start_date, end_date, parking_location, color, status, customer_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
-				[r.index, r.name, r.rvType, r.phoneNumber, r.notes, r.startDate, r.endDate, r.parkingLocation, r.color, r.status, r.customerId ?? null]
+				'INSERT INTO reservations (id, name, rv_type, eta, phone_number, notes, start_date, end_date, parking_location, color, status, created_at, customer_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+				[
+					r.index,
+					r.name,
+					r.rvType,
+					r.eta,
+					r.phoneNumber,
+					r.notes,
+					r.startDate,
+					r.endDate,
+					r.parkingLocation,
+					r.color,
+					r.status,
+					r.createdAt,
+					r.customerId ?? null
+				]
 			);
 		}
 

--- a/src/lib/infrastructure/storage/sqlite/migrations/006_reservation_eta_created_at.ts
+++ b/src/lib/infrastructure/storage/sqlite/migrations/006_reservation_eta_created_at.ts
@@ -1,0 +1,25 @@
+import type { Database } from '../types';
+
+export const version = 6;
+
+async function hasColumn(db: Database, table: string, column: string): Promise<boolean> {
+	const rows = await db.select<{ name: string }>(`PRAGMA table_info(${table})`);
+	return rows.some((r) => r.name === column);
+}
+
+export async function up(db: Database): Promise<void> {
+	if (!(await hasColumn(db, 'reservations', 'eta'))) {
+		await db.execute(`
+			ALTER TABLE reservations ADD COLUMN eta TEXT NOT NULL DEFAULT ''
+		`);
+	}
+
+	if (!(await hasColumn(db, 'reservations', 'created_at'))) {
+		await db.execute(`
+			ALTER TABLE reservations ADD COLUMN created_at TEXT NOT NULL DEFAULT ''
+		`);
+		await db.execute(`
+			UPDATE reservations SET created_at = start_date WHERE created_at = ''
+		`);
+	}
+}

--- a/src/lib/infrastructure/storage/sqlite/migrations/index.ts
+++ b/src/lib/infrastructure/storage/sqlite/migrations/index.ts
@@ -4,11 +4,13 @@ import * as m002 from './002_add_status';
 import * as m003 from './003_customers';
 import * as m004 from './004_add_rv_type';
 import * as m005 from './005_repair_rv_type';
+import * as m006 from './006_reservation_eta_created_at';
 
 export const allMigrations: Migration[] = [
 	{ version: m001.version, up: m001.up },
 	{ version: m002.version, up: m002.up },
 	{ version: m003.version, up: m003.up },
 	{ version: m004.version, up: m004.up },
-	{ version: m005.version, up: m005.up }
+	{ version: m005.version, up: m005.up },
+	{ version: m006.version, up: m006.up }
 ];

--- a/src/lib/infrastructure/storage/sqlite/schema.sql
+++ b/src/lib/infrastructure/storage/sqlite/schema.sql
@@ -18,6 +18,8 @@ CREATE TABLE IF NOT EXISTS parking_locations (
 CREATE TABLE IF NOT EXISTS reservations (
   id                INTEGER PRIMARY KEY,  -- matches Reservation.index
   name              TEXT    NOT NULL,
+  rv_type           TEXT    NOT NULL DEFAULT '',
+  eta               TEXT    NOT NULL DEFAULT '',
   phone_number      TEXT    NOT NULL DEFAULT '',
   notes             TEXT    NOT NULL DEFAULT '',
   start_date        TEXT    NOT NULL,      -- YYYY-MM-DD
@@ -25,6 +27,8 @@ CREATE TABLE IF NOT EXISTS reservations (
   parking_location  TEXT    NOT NULL REFERENCES parking_locations(name),
   color             TEXT    NOT NULL DEFAULT 'blue',
   status            TEXT    NOT NULL DEFAULT 'reserved',
+  created_at        TEXT    NOT NULL DEFAULT '',
+  customer_id       TEXT,
   CHECK (start_date < end_date),
   CHECK (color IN ('red','green','blue','yellow','pink','orange','purple'))
 );

--- a/src/lib/reservations.ts
+++ b/src/lib/reservations.ts
@@ -14,6 +14,7 @@ export {
 	getStatusLabel,
 	isReservationColor,
 	isReservationStatus,
+	normalizeEta,
 	normalizeName,
 	normalizePhoneNumber,
 	normalizeReservationNotes,

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment';
 import { isIsoDateString } from '$lib/date';
-import { DEFAULT_RESERVATION_STATUS, isReservationColor, isReservationStatus, normalizePhoneNumber, sanitizeReservationNotes } from '$lib/reservations';
+import { DEFAULT_RESERVATION_STATUS, isReservationColor, isReservationStatus, normalizeEta, normalizePhoneNumber, sanitizeReservationNotes } from '$lib/reservations';
 import type { AutoBackupIntervalMinutes, PersistedAppData, Reservation, ReservationStatus, SiteSettings } from '$lib/types';
 import { AUTO_BACKUP_INTERVALS } from '$lib/types';
 
@@ -75,12 +75,18 @@ export function sanitizeReservation(value: unknown): Reservation | null {
   const customerId = typeof raw.customerId === 'string' && UUID_RE.test(raw.customerId) ? raw.customerId : undefined;
 
   const rvType = typeof raw.rvType === 'string' ? raw.rvType.trim() : '';
+  const eta = typeof raw.eta === 'string' ? normalizeEta(raw.eta) : '';
+  const createdAt =
+    typeof raw.createdAt === 'string' && raw.createdAt.trim()
+      ? raw.createdAt.trim()
+      : raw.startDate;
 
   return {
     index: raw.index,
     firstCellId: raw.firstCellId,
     name: raw.name.trim(),
     rvType,
+    eta,
     phoneNumber,
     notes,
     startDate: raw.startDate,
@@ -88,6 +94,7 @@ export function sanitizeReservation(value: unknown): Reservation | null {
     parkingLocation: raw.parkingLocation.trim(),
     color: raw.color,
     status,
+    createdAt,
     customerId
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,7 @@ export interface Reservation {
   firstCellId: string;
   name: string;
   rvType: string;
+  eta: string;
   phoneNumber: string;
   notes: string;
   startDate: string;
@@ -26,6 +27,7 @@ export interface Reservation {
   parkingLocation: string;
   color: ReservationColor;
   status: ReservationStatus;
+  createdAt: string;
   customerId?: string;
 }
 
@@ -45,6 +47,7 @@ export interface ReservationFormValues {
   index?: number;
   name: string;
   rvType: string;
+  eta?: string;
   phoneNumber: string;
   notes: string;
   startDate: string;
@@ -52,6 +55,7 @@ export interface ReservationFormValues {
   parkingLocation: string;
   color: ReservationColor;
   status: ReservationStatus;
+  createdAt?: string;
   customerId?: string;
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,31 +2,22 @@
   import '../app.css';
   import { get } from 'svelte/store';
   import { onMount, setContext } from 'svelte';
+  import { createCurrentBackupContent } from '$lib/app/backup-content';
   import { getAppServices, registerPersistenceLifecycleHandlers } from '$lib/app/composition';
   import { startAutoBackupTimer } from '$lib/app/auto-backup';
   import { createForcedBackup } from '$lib/app/forced-backup';
   import { createUpdateChecker } from '$lib/app/update-checker';
-  import { createBackup } from '$lib/domain/backup';
   import { siteSettingsStore } from '$lib/site-settings';
-  import { rvReservationStore } from '$lib/state';
-  import { customerStore } from '$lib/customer-state';
   import UndoToast from '$lib/components/UndoToast.svelte';
 
   // Create update checker at component init so setContext works for child routes.
   // The actual check is deferred to onMount after persistence is ready.
   const { desktop } = getAppServices();
-  function getBackupContent(): string {
-    const state = get(rvReservationStore);
-    const settings = get(siteSettingsStore);
-    const customers = customerStore.getAll();
-    const backup = createBackup(state.reservations, state.parkingLocations, settings, customers);
-    return JSON.stringify(backup, null, 2);
-  }
 
   const updateChecker = desktop.isDesktop ? createUpdateChecker(desktop, {
     createPreUpdateBackup: () => createForcedBackup({
       desktop,
-      getBackupContent,
+      getBackupContent: createCurrentBackupContent,
       getAutoBackupDirectory: () => get(siteSettingsStore).autoBackup?.directoryPath,
       onSuccess: async (timestamp) => { await siteSettingsStore.recordAutoBackup(timestamp); }
     })
@@ -57,7 +48,7 @@
           const settings = get(siteSettingsStore);
           return settings.autoBackup ?? { intervalMinutes: 0, directoryPath: null, lastBackupAt: null };
         },
-        getBackupContent,
+        getBackupContent: createCurrentBackupContent,
         desktop,
         onSuccess: async (timestamp) => { await siteSettingsStore.recordAutoBackup(timestamp); },
         onError: (err) => console.error('Auto-backup failed:', err)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
     formatTimestamp,
     getTodayIsoLocal
   } from '$lib/date';
-  import { computeDailySummary } from '$lib/domain/reservations/daily-summary';
+  import { computeDailySummary, countCurrentAndFutureReservations } from '$lib/domain/reservations';
   import { buildCellId, buildOccupancyMap, rangesOverlap } from '$lib/reservations';
   import { enumerateDates } from '$lib/date';
   import {
@@ -34,9 +34,9 @@
   const DAYS_BEFORE_TODAY = 45;
   const TOTAL_DATE_COLUMNS = 540;
 
-  const todayIso = getTodayIsoLocal();
-  const gridStartDate = addDays(todayIso, -DAYS_BEFORE_TODAY);
-  const dateColumns = Array.from({ length: TOTAL_DATE_COLUMNS }, (_, index) => addDays(gridStartDate, index));
+  let todayIso = getTodayIsoLocal();
+  $: gridStartDate = addDays(todayIso, -DAYS_BEFORE_TODAY);
+  $: dateColumns = Array.from({ length: TOTAL_DATE_COLUMNS }, (_, index) => addDays(gridStartDate, index));
 
   let gridScroller: HTMLDivElement | null = null;
   let nowMs = Date.now();
@@ -86,6 +86,7 @@
   let modalDraft: ReservationFormValues = {
     name: '',
     rvType: '',
+    eta: '',
     phoneNumber: '',
     notes: '',
     startDate: todayIso,
@@ -116,6 +117,7 @@
       index: res.index,
       name: res.name,
       rvType: res.rvType,
+      eta: res.eta,
       phoneNumber: res.phoneNumber,
       notes: res.notes,
       startDate: res.startDate,
@@ -136,12 +138,26 @@
     contextMenu = null;
   }
 
+  async function handleContextMenuCopyDetails(): Promise<void> {
+    if (!contextMenu) return;
+    const text = getReservationDetailsText(contextMenu.reservation);
+    contextMenu = null;
+
+    try {
+      await navigator.clipboard.writeText(text);
+      showToast('Reservation details copied');
+    } catch {
+      showToast('Unable to copy reservation details');
+    }
+  }
+
   function openReservationFromSearch(reservation: Reservation): void {
     modalMode = 'edit';
     modalDraft = {
       index: reservation.index,
       name: reservation.name,
       rvType: reservation.rvType,
+      eta: reservation.eta,
       phoneNumber: reservation.phoneNumber,
       notes: reservation.notes,
       startDate: reservation.startDate,
@@ -149,6 +165,7 @@
       parkingLocation: reservation.parkingLocation,
       color: reservation.color,
       status: reservation.status,
+      createdAt: reservation.createdAt,
       customerId: reservation.customerId
     };
     modalErrors = [];
@@ -304,6 +321,10 @@
     ])
   ) as Record<string, number>;
   $: saveStatus = getSaveStatus($rvReservationStore.lastSavedAt, nowMs);
+  $: activeReservationCount = countCurrentAndFutureReservations(
+    $rvReservationStore.reservations,
+    todayIso
+  );
   $: dailySummary = computeDailySummary(
     $rvReservationStore.reservations,
     $rvReservationStore.parkingLocations,
@@ -357,6 +378,7 @@
     modalDraft = {
       name: '',
       rvType: '',
+      eta: '',
       phoneNumber: '',
       notes: '',
       startDate: todayIso,
@@ -382,6 +404,7 @@
         index: reservation.index,
         name: reservation.name,
         rvType: reservation.rvType,
+        eta: reservation.eta,
         phoneNumber: reservation.phoneNumber,
         notes: reservation.notes,
         startDate: reservation.startDate,
@@ -389,6 +412,7 @@
         parkingLocation: reservation.parkingLocation,
         color: reservation.color,
         status: reservation.status,
+        createdAt: reservation.createdAt,
         customerId: reservation.customerId
       };
     } else {
@@ -396,6 +420,7 @@
       modalDraft = {
         name: '',
         rvType: '',
+        eta: '',
         phoneNumber: '',
         notes: '',
         startDate: dateIso,
@@ -453,6 +478,7 @@
     modalDraft = {
       name,
       rvType,
+      eta: '',
       phoneNumber,
       notes,
       startDate: todayIso,
@@ -470,11 +496,23 @@
       return `Click to add reservation at ${location} on ${formatScheduleHeader(dateIso)}`;
     }
 
+    return getReservationDetailsText(reservation);
+  }
+
+  function getReservationDetailsText(reservation: Reservation): string {
     const lines = [
       `${reservation.name} (${formatReservationDetail(reservation.startDate)} \u2192 ${formatReservationDetail(reservation.endDate)})`,
       `Status: ${STATUS_LABELS[reservation.status]}`,
       `Site: ${reservation.parkingLocation}`
     ];
+
+    if (reservation.rvType) {
+      lines.push(`RV Type: ${reservation.rvType}`);
+    }
+
+    if (reservation.eta) {
+      lines.push(`ETA: ${reservation.eta}`);
+    }
 
     if (reservation.phoneNumber) {
       lines.push(`Phone: ${reservation.phoneNumber}`);
@@ -535,6 +573,7 @@
 
     const displayTicker = window.setInterval(() => {
       nowMs = Date.now();
+      todayIso = getTodayIsoLocal();
     }, 60_000);
 
     return () => {
@@ -607,7 +646,7 @@
     <div class="toolbar-right">
       <ReservationSearch reservations={$rvReservationStore.reservations} on:select={handleSearchSelect} />
       <button type="button" class="new-reservation-btn" data-testid="new-reservation-btn" on:click={openNewReservationModal}>+ New Reservation</button>
-      <span class="badge">{ $rvReservationStore.reservations.length } res</span>
+      <span class="badge" data-testid="reservation-count-badge">{activeReservationCount} res</span>
       <span class="badge">{ $rvReservationStore.parkingLocations.length } sites</span>
       <span class="badge save-badge" aria-live="polite">{saveStatus}</span>
       <a href="/customers" class="settings-link" title="Customers" aria-label="Customers" data-testid="customers-link">
@@ -775,6 +814,16 @@
       role="menu"
     >
       <div class="context-menu-header">{contextMenu.reservation.name}</div>
+      <button
+        type="button"
+        class="context-menu-item"
+        role="menuitem"
+        on:click={handleContextMenuCopyDetails}
+      >
+        <span class="context-menu-icon" aria-hidden="true">⧉</span>
+        <span>Copy details</span>
+      </button>
+      <div class="context-menu-separator" role="separator"></div>
       {#each RESERVATION_STATUSES as statusValue}
         <button
           type="button"
@@ -1452,6 +1501,12 @@
   .context-menu-item.active {
     background: #e0ebf9;
     font-weight: 600;
+  }
+
+  .context-menu-separator {
+    height: 1px;
+    background: #eef2f7;
+    margin: 0.2rem 0;
   }
 
   .context-menu-swatch {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -12,7 +12,8 @@
   import { AUTO_BACKUP_INTERVALS, type AutoBackupIntervalMinutes } from '$lib/types';
   import type { UpdateChecker, UpdateState } from '$lib/app/update-checker';
   import { readable } from 'svelte/store';
-  import { backupStatus } from '$lib/app/auto-backup';
+  import { backupStatus, clearBackupStatus, recordBackupError } from '$lib/app/auto-backup';
+  import { writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
 
   const SITE_NAME_MAX_LENGTH = 80;
 
@@ -54,6 +55,7 @@
 
   // Backup import state
   let backupImporting = false;
+  let manualBackupRunning = false;
 
   let locationPanelError = '';
 
@@ -184,13 +186,10 @@
 
   const JSON_FILTERS = [{ name: 'JSON', extensions: ['json'] }];
 
-  async function handleExportBackup(): Promise<void> {
-    clearMessages();
-
+  function getBackupContent(): string {
     const state = get(rvReservationStore);
     const settings = get(siteSettingsStore);
     const customers = customerStore.getAll();
-
     const backup = createBackup(
       state.reservations,
       state.parkingLocations,
@@ -198,8 +197,14 @@
       customers
     );
 
+    return JSON.stringify(backup, null, 2);
+  }
+
+  async function handleExportBackup(): Promise<void> {
+    clearMessages();
+
     const filename = generateBackupFilename();
-    const content = JSON.stringify(backup, null, 2);
+    const content = getBackupContent();
 
     try {
       const { desktop } = getAppServices();
@@ -210,6 +215,47 @@
     } catch (err) {
       console.error('Backup export failed:', err);
       errorMessage = `Export failed: ${err instanceof Error ? err.message : 'unknown error'}`;
+    }
+  }
+
+  async function handleBackupNow(): Promise<void> {
+    clearMessages();
+    const directoryPath = $siteSettingsStore.autoBackup?.directoryPath;
+    if (!directoryPath) {
+      errorMessage = 'Choose a backup folder before running Backup Now.';
+      return;
+    }
+
+    manualBackupRunning = true;
+    try {
+      const { desktop } = getAppServices();
+      const result = await writeVerifiedBackupToDirectory({
+        desktop,
+        directoryPath,
+        getBackupContent
+      });
+
+      if (!result.ok) {
+        errorMessage = result.error;
+        recordBackupError(result.error);
+        return;
+      }
+
+      const recorded = await siteSettingsStore.recordAutoBackup(result.timestamp);
+      if (!recorded.ok) {
+        clearBackupStatus();
+        errorMessage = recorded.errors?.[0] ?? 'Backup was created, but the timestamp could not be saved.';
+        return;
+      }
+
+      clearBackupStatus();
+      successMessage = 'Backup created successfully.';
+    } catch (err) {
+      const message = `Backup failed: ${err instanceof Error ? err.message : 'unknown error'}`;
+      errorMessage = message;
+      recordBackupError(message);
+    } finally {
+      manualBackupRunning = false;
     }
   }
 
@@ -500,8 +546,18 @@
         </label>
 
         <div class="meta" data-testid="auto-backup-last">
-          Last auto-backup: {formatLastBackup($siteSettingsStore.autoBackup?.lastBackupAt)}
+          Last backup: {formatLastBackup($siteSettingsStore.autoBackup?.lastBackupAt)}
         </div>
+
+        <button
+          type="button"
+          class="primary"
+          disabled={!$siteSettingsStore.autoBackup?.directoryPath || manualBackupRunning}
+          on:click={handleBackupNow}
+          data-testid="auto-backup-now-btn"
+        >
+          {manualBackupRunning ? 'Backing up...' : 'Backup Now'}
+        </button>
 
         {#if $backupStatus.lastError}
           <div class="backup-error" role="alert" data-testid="auto-backup-error">

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -6,14 +6,15 @@
   import { customerStore } from '$lib/customer-state';
   import ParkingLocationsPanel from '$lib/components/ParkingLocationsPanel.svelte';
   import { rvReservationStore } from '$lib/state';
-  import { createBackup, generateBackupFilename, normalizeBackupForRestore, validateBackup, type AppBackup } from '$lib/domain/backup';
+  import { generateBackupFilename, normalizeBackupForRestore, validateBackup, type AppBackup } from '$lib/domain/backup';
   import { restoreBackup, type RestoreStores } from '$lib/application/use-cases/restore-backup';
+  import { createCurrentBackupContent } from '$lib/app/backup-content';
   import { getAppServices } from '$lib/app/composition';
   import { AUTO_BACKUP_INTERVALS, type AutoBackupIntervalMinutes } from '$lib/types';
   import type { UpdateChecker, UpdateState } from '$lib/app/update-checker';
   import { readable } from 'svelte/store';
-  import { backupStatus, clearBackupStatus, recordBackupError } from '$lib/app/auto-backup';
-  import { writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
+  import { backupStatus, runManualBackupNow } from '$lib/app/auto-backup';
+  import { JSON_BACKUP_FILTERS } from '$lib/app/forced-backup';
 
   const SITE_NAME_MAX_LENGTH = 80;
 
@@ -184,31 +185,15 @@
     }
   }
 
-  const JSON_FILTERS = [{ name: 'JSON', extensions: ['json'] }];
-
-  function getBackupContent(): string {
-    const state = get(rvReservationStore);
-    const settings = get(siteSettingsStore);
-    const customers = customerStore.getAll();
-    const backup = createBackup(
-      state.reservations,
-      state.parkingLocations,
-      settings,
-      customers
-    );
-
-    return JSON.stringify(backup, null, 2);
-  }
-
   async function handleExportBackup(): Promise<void> {
     clearMessages();
 
     const filename = generateBackupFilename();
-    const content = getBackupContent();
+    const content = createCurrentBackupContent();
 
     try {
       const { desktop } = getAppServices();
-      const saved = await desktop.saveFile(filename, content, JSON_FILTERS);
+      const saved = await desktop.saveFile(filename, content, JSON_BACKUP_FILTERS);
       if (saved) {
         successMessage = 'Backup exported successfully.';
       }
@@ -229,31 +214,19 @@
     manualBackupRunning = true;
     try {
       const { desktop } = getAppServices();
-      const result = await writeVerifiedBackupToDirectory({
+      const result = await runManualBackupNow({
         desktop,
         directoryPath,
-        getBackupContent
+        getBackupContent: createCurrentBackupContent,
+        onSuccess: (timestamp) => siteSettingsStore.recordAutoBackup(timestamp)
       });
 
       if (!result.ok) {
         errorMessage = result.error;
-        recordBackupError(result.error);
         return;
       }
 
-      const recorded = await siteSettingsStore.recordAutoBackup(result.timestamp);
-      if (!recorded.ok) {
-        clearBackupStatus();
-        errorMessage = recorded.errors?.[0] ?? 'Backup was created, but the timestamp could not be saved.';
-        return;
-      }
-
-      clearBackupStatus();
       successMessage = 'Backup created successfully.';
-    } catch (err) {
-      const message = `Backup failed: ${err instanceof Error ? err.message : 'unknown error'}`;
-      errorMessage = message;
-      recordBackupError(message);
     } finally {
       manualBackupRunning = false;
     }
@@ -265,7 +238,7 @@
 
     try {
       const { desktop } = getAppServices();
-      const text = await desktop.openFile(JSON_FILTERS);
+      const text = await desktop.openFile(JSON_BACKUP_FILTERS);
       if (!text) return;
 
       let parsed: unknown;

--- a/tests/e2e/admin.spec.ts
+++ b/tests/e2e/admin.spec.ts
@@ -15,6 +15,38 @@ async function resetApp(page: Page) {
 	await page.waitForTimeout(300);
 }
 
+async function installDesktopBackupMock(page: Page) {
+	await page.addInitScript(() => {
+		type BackupWrite = { path: string; content: string };
+		type BackupTestWindow = Window & {
+			__RV_TEST_DESKTOP_CAPABILITIES__?: unknown;
+			__RV_BACKUP_WRITES__?: BackupWrite[];
+			__RV_BACKUP_MISMATCH__?: boolean;
+		};
+
+		const testWindow = window as BackupTestWindow;
+		const files = new Map<string, string>();
+		testWindow.__RV_BACKUP_WRITES__ = [];
+		testWindow.__RV_BACKUP_MISMATCH__ = false;
+		testWindow.__RV_TEST_DESKTOP_CAPABILITIES__ = {
+			isDesktop: true,
+			getVersion: async () => 'e2e-test',
+			pickDirectory: async () => '/mock-backups',
+			writeFileToPath: async (filePath: string, content: string) => {
+				testWindow.__RV_BACKUP_WRITES__?.push({ path: filePath, content });
+				files.set(filePath, content);
+			},
+			readFileFromPath: async (filePath: string) => {
+				const content = files.get(filePath) ?? '';
+				if (testWindow.__RV_BACKUP_MISMATCH__ && filePath.includes('rv-backup-')) {
+					return `${content}\ncorrupt`;
+				}
+				return content;
+			}
+		};
+	});
+}
+
 test.describe('Settings page', () => {
 	test.beforeEach(async ({ page }) => {
 		await clearStorage(page);
@@ -132,6 +164,63 @@ test.describe('Backup & Restore section on settings page', () => {
 	test('backup panel has correct heading', async ({ page }) => {
 		await page.goto('/admin');
 		await expect(page.locator('h2:has-text("Backup & Restore")')).toBeVisible();
+	});
+});
+
+test.describe('Automatic backup manual trigger', () => {
+	test.beforeEach(async ({ page }) => {
+		await installDesktopBackupMock(page);
+		await clearStorage(page);
+	});
+
+	test('backup now is disabled until a backup folder is configured', async ({ page }) => {
+		await page.goto('/admin');
+
+		await expect(page.locator('[data-testid="auto-backup-panel"]')).toBeVisible();
+		await expect(page.locator('[data-testid="auto-backup-now-btn"]')).toBeDisabled();
+		await expect(page.locator('[data-testid="auto-backup-last"]')).toContainText('Last backup: Never');
+	});
+
+	test('backup now writes verified backup JSON to the configured folder', async ({ page }) => {
+		await page.goto('/admin');
+
+		await page.locator('[data-testid="auto-backup-pick-dir"]').click();
+		await expect(page.locator('[data-testid="auto-backup-directory"]')).toHaveValue('/mock-backups');
+
+		await page.locator('[data-testid="auto-backup-now-btn"]').click();
+
+		await expect(page.locator('.message.success')).toContainText('Backup created successfully');
+		await expect(page.locator('[data-testid="auto-backup-last"]')).not.toContainText('Never');
+
+		const writes = await page.evaluate(() => {
+			const testWindow = window as Window & { __RV_BACKUP_WRITES__?: { path: string; content: string }[] };
+			return (testWindow.__RV_BACKUP_WRITES__ ?? []).filter((write) => /\/rv-backup-\d/.test(write.path));
+		});
+
+		expect(writes).toHaveLength(1);
+		expect(writes[0].path).toMatch(/^\/mock-backups\/rv-backup-\d{4}-\d{2}-\d{2}-\d{6}\.json$/);
+		const backup = JSON.parse(writes[0].content);
+		expect(backup.schema.version).toBe(1);
+		expect(backup.schema.appName).toBe('rv-reservation-system');
+		expect(Array.isArray(backup.data.reservations)).toBe(true);
+		expect(Array.isArray(backup.data.parkingLocations)).toBe(true);
+		expect(Array.isArray(backup.data.customers)).toBe(true);
+	});
+
+	test('backup now reports an error when read-back verification fails', async ({ page }) => {
+		await page.goto('/admin');
+
+		await page.locator('[data-testid="auto-backup-pick-dir"]').click();
+		await page.evaluate(() => {
+			const testWindow = window as Window & { __RV_BACKUP_MISMATCH__?: boolean };
+			testWindow.__RV_BACKUP_MISMATCH__ = true;
+		});
+
+		await page.locator('[data-testid="auto-backup-now-btn"]').click();
+
+		await expect(page.locator('.message.error')).toContainText('Backup verification failed');
+		await expect(page.locator('[data-testid="auto-backup-error"]')).toContainText('Backup verification failed');
+		await expect(page.locator('[data-testid="auto-backup-last"]')).toContainText('Last backup: Never');
 	});
 });
 

--- a/tests/e2e/compact-view.spec.ts
+++ b/tests/e2e/compact-view.spec.ts
@@ -41,13 +41,14 @@ test.describe('Compact View Toggle', () => {
 		const normalHeight = (await cell.boundingBox())!.height;
 
 		await compactToggle(page).click();
-		await page.waitForTimeout(200);
-
-		await cell.scrollIntoViewIfNeeded();
-		const compactHeight = (await cell.boundingBox())!.height;
-
-		expect(compactHeight).toBeLessThan(normalHeight);
 		await expect(compactToggle(page)).toHaveAttribute('aria-pressed', 'true');
+
+		await expect
+			.poll(async () => {
+				await cell.scrollIntoViewIfNeeded();
+				return (await cell.boundingBox())?.height ?? normalHeight;
+			})
+			.toBeLessThan(normalHeight);
 	});
 
 	test('compact mode persists across page reload', async ({ page }) => {

--- a/tests/e2e/reservations.spec.ts
+++ b/tests/e2e/reservations.spec.ts
@@ -142,6 +142,83 @@ test.describe('Reservation CRUD', () => {
 		await expect(modal(page).locator('.error-box')).toBeVisible();
 		await expect(modal(page).locator('.error-box')).toContainText('Overlap');
 	});
+
+	test('ETA, RV type, tooltip, and created date persist on reservations', async ({ page }) => {
+		const today = getTodayIso();
+		const endDate = offsetDate(3);
+
+		await page.getByTestId('new-reservation-btn').click();
+		await expect(modal(page)).toBeVisible();
+
+		await modal(page).locator('input[placeholder="Guest name"]').fill('ETA Guest');
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+		await modal(page).getByTestId('rv-type-input').fill('Class A');
+		await modal(page).getByTestId('reservation-eta-input').fill('2:30 PM');
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.scrollIntoViewIfNeeded();
+		await expect(occupied).toHaveAttribute('title', /RV Type: Class A/);
+		await expect(occupied).toHaveAttribute('title', /ETA: 2:30 PM/);
+
+		await occupied.click();
+		await expect(modal(page)).toBeVisible();
+		await expect(modal(page).getByTestId('rv-type-input')).toHaveValue('Class A');
+		await expect(modal(page).getByTestId('reservation-eta-input')).toHaveValue('2:30 PM');
+		await expect(modal(page).getByTestId('reservation-created-at')).toContainText('Created');
+	});
+
+	test('reservation count excludes fully checked-out past stays', async ({ page }) => {
+		const pastStart = offsetDate(-10);
+		const pastEnd = offsetDate(-8);
+		const futureStart = offsetDate(2);
+		const futureEnd = offsetDate(4);
+
+		await createReservation(page, { name: 'Past Guest', startDate: pastStart, endDate: pastEnd });
+		await expect(page.getByTestId('reservation-count-badge')).toHaveText('0 res');
+
+		await createReservation(page, { name: 'Future Guest', startDate: futureStart, endDate: futureEnd });
+		await expect(page.getByTestId('reservation-count-badge')).toHaveText('1 res');
+	});
+
+	test('right-click context menu can copy reservation details', async ({ page }) => {
+		await page.addInitScript(() => {
+			Object.defineProperty(navigator, 'clipboard', {
+				value: {
+					writeText: async (text: string) => {
+						(window as Window & { __COPIED_RESERVATION__?: string }).__COPIED_RESERVATION__ = text;
+					}
+				},
+				configurable: true
+			});
+		});
+		await resetApp(page);
+
+		const today = getTodayIso();
+		const endDate = offsetDate(3);
+		await page.getByTestId('new-reservation-btn').click();
+		await modal(page).locator('input[placeholder="Guest name"]').fill('Copy Guest');
+		await modal(page).locator('input[type="date"]').first().fill(today);
+		await modal(page).locator('input[type="date"]').nth(1).fill(endDate);
+		await modal(page).getByTestId('rv-type-input').fill('Travel Trailer');
+		await modal(page).getByTestId('reservation-eta-input').fill('4 PM');
+		await modal(page).locator('button[type="submit"]').click();
+		await expect(modal(page)).not.toBeVisible();
+
+		const occupied = page.locator('.grid-cell.occupied').first();
+		await occupied.click({ button: 'right' });
+		await expect(page.locator('.context-menu')).toBeVisible();
+		await page.getByRole('menuitem', { name: 'Copy details' }).click();
+
+		const copied = await page.evaluate(
+			() => (window as Window & { __COPIED_RESERVATION__?: string }).__COPIED_RESERVATION__
+		);
+		expect(copied).toContain('Copy Guest');
+		expect(copied).toContain('RV Type: Travel Trailer');
+		expect(copied).toContain('ETA: 4 PM');
+	});
 });
 
 test.describe('Modal accessibility and UX', () => {

--- a/tests/unit/auto-backup.test.ts
+++ b/tests/unit/auto-backup.test.ts
@@ -42,6 +42,7 @@ describe('startAutoBackupTimer', () => {
 
 	function makeDeps(config: AutoBackupConfig, overrides?: Partial<AutoBackupDeps>): AutoBackupDeps & { written: string[]; errors: unknown[] } {
 		const written: string[] = [];
+		const files = new Map<string, string>();
 		const errors: unknown[] = [];
 		return {
 			written,
@@ -54,7 +55,11 @@ describe('startAutoBackupTimer', () => {
 				getVersion: async () => null,
 				saveFile: async () => false,
 				openFile: async () => null,
-				writeFileToPath: async (path: string) => { written.push(path); },
+				writeFileToPath: async (path: string, content: string) => {
+					written.push(path);
+					files.set(path, content);
+				},
+				readFileFromPath: async (path: string) => files.get(path) ?? '',
 				pickDirectory: async () => null,
 				checkForUpdate: async () => null,
 				checkBetaUpdate: async () => null,
@@ -107,6 +112,7 @@ describe('startAutoBackupTimer', () => {
 				saveFile: async () => false,
 				openFile: async () => null,
 				writeFileToPath: async () => { throw new Error('disk full'); },
+				readFileFromPath: async () => '',
 				pickDirectory: async () => null,
 				checkForUpdate: async () => null,
 				checkBetaUpdate: async () => null,
@@ -120,7 +126,38 @@ describe('startAutoBackupTimer', () => {
 		await vi.advanceTimersByTimeAsync(0);
 
 		expect(deps.errors.length).toBe(1);
-		expect((deps.errors[0] as Error).message).toBe('disk full');
+		expect((deps.errors[0] as Error).message).toBe('Backup failed: disk full');
+		stop();
+	});
+
+	it('calls onError and skips success when read-back verification fails', async () => {
+		const config: AutoBackupConfig = { intervalMinutes: 30, directoryPath: '/backups', lastBackupAt: null };
+		let successTimestamp: string | null = null;
+		const deps = makeDeps(config, {
+			desktop: {
+				isDesktop: true,
+				getAppDataDir: async () => null,
+				getVersion: async () => null,
+				saveFile: async () => false,
+				openFile: async () => null,
+				writeFileToPath: async () => {},
+				readFileFromPath: async () => '{"test": false}',
+				pickDirectory: async () => null,
+				checkForUpdate: async () => null,
+				checkBetaUpdate: async () => null,
+				downloadUpdate: async () => false,
+				installUpdateAndRestart: async () => false,
+				relaunch: async () => {}
+			},
+			onSuccess: async (ts) => { successTimestamp = ts; }
+		});
+		const stop = startAutoBackupTimer(deps);
+
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(successTimestamp).toBeNull();
+		expect(deps.errors.length).toBe(1);
+		expect((deps.errors[0] as Error).message).toBe('Backup verification failed: written file contents did not match generated backup.');
 		stop();
 	});
 

--- a/tests/unit/auto-backup.test.ts
+++ b/tests/unit/auto-backup.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isBackupDue, runManualBackupNow, startAutoBackupTimer, type AutoBackupDeps } from '$lib/app/auto-backup';
+import {
+	isBackupDue,
+	runBackupOnExit,
+	runManualBackupNow,
+	startAutoBackupTimer,
+	type AutoBackupDeps
+} from '$lib/app/auto-backup';
 import type { AutoBackupConfig } from '$lib/types';
 import { createDesktopCapabilitiesMock } from './desktop-capabilities.fixture';
 
@@ -58,6 +64,67 @@ describe('runManualBackupNow', () => {
 		});
 
 		expect(result).toEqual({ ok: false, error: 'Settings write failed' });
+	});
+});
+
+describe('runBackupOnExit', () => {
+	it('does nothing when no backup directory is configured', async () => {
+		const desktopMock = createDesktopCapabilitiesMock();
+
+		await expect(
+			runBackupOnExit({
+				desktop: desktopMock.desktop,
+				getConfig: () => ({ intervalMinutes: 30, directoryPath: null, lastBackupAt: null }),
+				getBackupContent: () => '{"test": true}',
+				onSuccess: async () => ({ ok: true })
+			})
+		).resolves.toBeUndefined();
+
+		expect(desktopMock.written).toHaveLength(0);
+	});
+
+	it('writes a verified backup when a backup directory is configured', async () => {
+		const desktopMock = createDesktopCapabilitiesMock();
+		const onSuccess = vi.fn(async () => ({ ok: true }));
+
+		await runBackupOnExit({
+			desktop: desktopMock.desktop,
+			getConfig: () => ({ intervalMinutes: 30, directoryPath: '/backups', lastBackupAt: null }),
+			getBackupContent: () => '{"test": true}',
+			onSuccess
+		});
+
+		expect(desktopMock.written).toHaveLength(1);
+		expect(desktopMock.written[0]).toMatch(/^\/backups\/rv-backup-.*\.json$/);
+		expect(onSuccess).toHaveBeenCalledOnce();
+	});
+
+	it('swallows backup failures so close can continue', async () => {
+		await expect(
+			runBackupOnExit({
+				desktop: createDesktopCapabilitiesMock({
+					writeFileToPath: async () => {
+						throw new Error('disk full');
+					}
+				}).desktop,
+				getConfig: () => ({ intervalMinutes: 30, directoryPath: '/backups', lastBackupAt: null }),
+				getBackupContent: () => '{"test": true}',
+				onSuccess: async () => ({ ok: true })
+			})
+		).resolves.toBeUndefined();
+	});
+
+	it('swallows config load failures so close can continue', async () => {
+		await expect(
+			runBackupOnExit({
+				desktop: createDesktopCapabilitiesMock().desktop,
+				getConfig: () => {
+					throw new Error('settings read failed');
+				},
+				getBackupContent: () => '{"test": true}',
+				onSuccess: async () => ({ ok: true })
+			})
+		).resolves.toBeUndefined();
 	});
 });
 

--- a/tests/unit/auto-backup.test.ts
+++ b/tests/unit/auto-backup.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isBackupDue, startAutoBackupTimer, type AutoBackupDeps } from '$lib/app/auto-backup';
+import { isBackupDue, runManualBackupNow, startAutoBackupTimer, type AutoBackupDeps } from '$lib/app/auto-backup';
 import type { AutoBackupConfig } from '$lib/types';
+import { createDesktopCapabilitiesMock } from './desktop-capabilities.fixture';
 
 describe('isBackupDue', () => {
 	it('returns false when interval is 0 (off)', () => {
@@ -31,6 +32,35 @@ describe('isBackupDue', () => {
 	});
 });
 
+describe('runManualBackupNow', () => {
+	it('writes a verified backup and records the timestamp', async () => {
+		const desktopMock = createDesktopCapabilitiesMock();
+		const onSuccess = vi.fn(async () => ({ ok: true }));
+
+		const result = await runManualBackupNow({
+			desktop: desktopMock.desktop,
+			directoryPath: '/backups',
+			getBackupContent: () => '{"test": true}',
+			onSuccess
+		});
+
+		expect(result).toEqual({ ok: true });
+		expect(desktopMock.written[0]).toMatch(/^\/backups\/rv-backup-.*\.json$/);
+		expect(onSuccess).toHaveBeenCalledOnce();
+	});
+
+	it('returns a timestamp persistence error without recording backup failure status', async () => {
+		const result = await runManualBackupNow({
+			desktop: createDesktopCapabilitiesMock().desktop,
+			directoryPath: '/backups',
+			getBackupContent: () => '{"test": true}',
+			onSuccess: async () => ({ ok: false, errors: ['Settings write failed'] })
+		});
+
+		expect(result).toEqual({ ok: false, error: 'Settings write failed' });
+	});
+});
+
 describe('startAutoBackupTimer', () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -41,32 +71,14 @@ describe('startAutoBackupTimer', () => {
 	});
 
 	function makeDeps(config: AutoBackupConfig, overrides?: Partial<AutoBackupDeps>): AutoBackupDeps & { written: string[]; errors: unknown[] } {
-		const written: string[] = [];
-		const files = new Map<string, string>();
+		const desktopMock = createDesktopCapabilitiesMock();
 		const errors: unknown[] = [];
 		return {
-			written,
+			written: desktopMock.written,
 			errors,
 			getConfig: () => config,
 			getBackupContent: () => '{"test": true}',
-			desktop: {
-				isDesktop: true,
-				getAppDataDir: async () => null,
-				getVersion: async () => null,
-				saveFile: async () => false,
-				openFile: async () => null,
-				writeFileToPath: async (path: string, content: string) => {
-					written.push(path);
-					files.set(path, content);
-				},
-				readFileFromPath: async (path: string) => files.get(path) ?? '',
-				pickDirectory: async () => null,
-				checkForUpdate: async () => null,
-				checkBetaUpdate: async () => null,
-				downloadUpdate: async () => false,
-				installUpdateAndRestart: async () => false,
-				relaunch: async () => {}
-			},
+			desktop: desktopMock.desktop,
 			onSuccess: async () => {},
 			onError: (err) => errors.push(err),
 			...overrides
@@ -102,26 +114,14 @@ describe('startAutoBackupTimer', () => {
 		stop();
 	});
 
-	it('calls onError when writeFileToPath throws', async () => {
-		const config: AutoBackupConfig = { intervalMinutes: 30, directoryPath: '/backups', lastBackupAt: null };
-		const deps = makeDeps(config, {
-			desktop: {
-				isDesktop: true,
-				getAppDataDir: async () => null,
-				getVersion: async () => null,
-				saveFile: async () => false,
-				openFile: async () => null,
-				writeFileToPath: async () => { throw new Error('disk full'); },
-				readFileFromPath: async () => '',
-				pickDirectory: async () => null,
-				checkForUpdate: async () => null,
-				checkBetaUpdate: async () => null,
-				downloadUpdate: async () => false,
-				installUpdateAndRestart: async () => false,
-				relaunch: async () => {}
-			}
-		});
-		const stop = startAutoBackupTimer(deps);
+		it('calls onError when writeFileToPath throws', async () => {
+			const config: AutoBackupConfig = { intervalMinutes: 30, directoryPath: '/backups', lastBackupAt: null };
+			const deps = makeDeps(config, {
+				desktop: createDesktopCapabilitiesMock({
+					writeFileToPath: async () => { throw new Error('disk full'); }
+				}).desktop
+			});
+			const stop = startAutoBackupTimer(deps);
 
 		await vi.advanceTimersByTimeAsync(0);
 
@@ -130,28 +130,17 @@ describe('startAutoBackupTimer', () => {
 		stop();
 	});
 
-	it('calls onError and skips success when read-back verification fails', async () => {
-		const config: AutoBackupConfig = { intervalMinutes: 30, directoryPath: '/backups', lastBackupAt: null };
-		let successTimestamp: string | null = null;
-		const deps = makeDeps(config, {
-			desktop: {
-				isDesktop: true,
-				getAppDataDir: async () => null,
-				getVersion: async () => null,
-				saveFile: async () => false,
-				openFile: async () => null,
-				writeFileToPath: async () => {},
-				readFileFromPath: async () => '{"test": false}',
-				pickDirectory: async () => null,
-				checkForUpdate: async () => null,
-				checkBetaUpdate: async () => null,
-				downloadUpdate: async () => false,
-				installUpdateAndRestart: async () => false,
-				relaunch: async () => {}
-			},
-			onSuccess: async (ts) => { successTimestamp = ts; }
-		});
-		const stop = startAutoBackupTimer(deps);
+		it('calls onError and skips success when read-back verification fails', async () => {
+			const config: AutoBackupConfig = { intervalMinutes: 30, directoryPath: '/backups', lastBackupAt: null };
+			let successTimestamp: string | null = null;
+			const deps = makeDeps(config, {
+				desktop: createDesktopCapabilitiesMock({
+					writeFileToPath: async () => {},
+					readFileFromPath: async () => '{"test": false}'
+				}).desktop,
+				onSuccess: async (ts) => { successTimestamp = ts; }
+			});
+			const stop = startAutoBackupTimer(deps);
 
 		await vi.advanceTimersByTimeAsync(0);
 

--- a/tests/unit/availability.test.ts
+++ b/tests/unit/availability.test.ts
@@ -8,6 +8,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		firstCellId: 'A|2025-06-01',
 		name: 'Guest',
 		rvType: '',
+		eta: '',
 		phoneNumber: '',
 		notes: '',
 		startDate: '2025-06-01',
@@ -15,6 +16,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		parkingLocation: 'Site A',
 		color: 'blue',
 		status: 'reserved',
+		createdAt: '2025-05-01T00:00:00.000Z',
 		...overrides
 	};
 }

--- a/tests/unit/backup.test.ts
+++ b/tests/unit/backup.test.ts
@@ -8,6 +8,7 @@ function makeFakeReservation(overrides: Partial<Reservation> = {}): Reservation 
 		firstCellId: 'A-01_2025-06-01',
 		name: 'Test Guest',
 		rvType: '',
+		eta: '',
 		phoneNumber: '555-1234',
 		notes: '',
 		startDate: '2025-06-01',
@@ -15,6 +16,7 @@ function makeFakeReservation(overrides: Partial<Reservation> = {}): Reservation 
 		parkingLocation: 'A-01',
 		color: 'blue',
 		status: 'reserved',
+		createdAt: '2025-05-01T00:00:00.000Z',
 		...overrides
 	};
 }

--- a/tests/unit/daily-summary.test.ts
+++ b/tests/unit/daily-summary.test.ts
@@ -8,6 +8,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		firstCellId: 'A::2026-03-07',
 		name: 'Test Guest',
 		rvType: '',
+		eta: '',
 		phoneNumber: '555-1234',
 		notes: '',
 		startDate: '2026-03-07',
@@ -15,6 +16,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		parkingLocation: 'A',
 		color: 'blue',
 		status: 'reserved',
+		createdAt: '2026-02-01T00:00:00.000Z',
 		...overrides
 	};
 }

--- a/tests/unit/desktop-capabilities.fixture.ts
+++ b/tests/unit/desktop-capabilities.fixture.ts
@@ -1,0 +1,39 @@
+import type { DesktopCapabilities } from '$lib/application/ports';
+
+export interface DesktopCapabilitiesMock {
+	desktop: DesktopCapabilities;
+	files: Map<string, string>;
+	written: string[];
+	writes: { path: string; content: string }[];
+}
+
+export function createDesktopCapabilitiesMock(
+	overrides: Partial<DesktopCapabilities> = {}
+): DesktopCapabilitiesMock {
+	const files = new Map<string, string>();
+	const written: string[] = [];
+	const writes: { path: string; content: string }[] = [];
+
+	const desktop: DesktopCapabilities = {
+		isDesktop: true,
+		getAppDataDir: async () => null,
+		getVersion: async () => null,
+		saveFile: async () => false,
+		openFile: async () => null,
+		writeFileToPath: async (path: string, content: string) => {
+			written.push(path);
+			writes.push({ path, content });
+			files.set(path, content);
+		},
+		readFileFromPath: async (path: string) => files.get(path) ?? '',
+		pickDirectory: async () => null,
+		checkForUpdate: async () => null,
+		checkBetaUpdate: async () => null,
+		downloadUpdate: async () => false,
+		installUpdateAndRestart: async () => false,
+		relaunch: async () => {},
+		...overrides
+	};
+
+	return { desktop, files, written, writes };
+}

--- a/tests/unit/forced-backup.test.ts
+++ b/tests/unit/forced-backup.test.ts
@@ -10,6 +10,7 @@ function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapab
 		saveFile: async () => false,
 		openFile: async () => null,
 		writeFileToPath: async () => {},
+		readFileFromPath: async () => '',
 		pickDirectory: async () => null,
 		checkForUpdate: async () => null,
 		checkBetaUpdate: async () => null,
@@ -23,10 +24,11 @@ function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapab
 describe('createForcedBackup', () => {
 	it('writes to the configured backup directory and records success', async () => {
 		const writeFileToPath = vi.fn(async (_path: string, _content: string) => {});
+		const readFileFromPath = vi.fn(async () => '{"ok":true}');
 		const onSuccess = vi.fn(async () => {});
 
 		const result = await createForcedBackup({
-			desktop: makeDesktop({ writeFileToPath }),
+			desktop: makeDesktop({ writeFileToPath, readFileFromPath }),
 			getBackupContent: () => '{"ok":true}',
 			getAutoBackupDirectory: () => '/backups',
 			onSuccess
@@ -37,6 +39,7 @@ describe('createForcedBackup', () => {
 		const [path, content] = writeFileToPath.mock.calls[0];
 		expect(path).toMatch(/^\/backups\/rv-backup-\d{4}-\d{2}-\d{2}-\d{6}\.json$/);
 		expect(content).toBe('{"ok":true}');
+		expect(readFileFromPath).toHaveBeenCalledWith(path);
 		expect(onSuccess).toHaveBeenCalledOnce();
 	});
 
@@ -85,5 +88,24 @@ describe('createForcedBackup', () => {
 			ok: false,
 			error: 'Backup failed: disk full'
 		});
+	});
+
+	it('does not record success when backup verification fails', async () => {
+		const onSuccess = vi.fn(async () => {});
+
+		const result = await createForcedBackup({
+			desktop: makeDesktop({
+				readFileFromPath: async () => '{"ok":false}'
+			}),
+			getBackupContent: () => '{"ok":true}',
+			getAutoBackupDirectory: () => '/backups',
+			onSuccess
+		});
+
+		expect(result).toEqual({
+			ok: false,
+			error: 'Backup verification failed: written file contents did not match generated backup.'
+		});
+		expect(onSuccess).not.toHaveBeenCalled();
 	});
 });

--- a/tests/unit/forced-backup.test.ts
+++ b/tests/unit/forced-backup.test.ts
@@ -1,25 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createForcedBackup, JSON_BACKUP_FILTERS } from '$lib/app/forced-backup';
-import type { DesktopCapabilities } from '$lib/application/ports';
-
-function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapabilities {
-	return {
-		isDesktop: true,
-		getAppDataDir: async () => null,
-		getVersion: async () => null,
-		saveFile: async () => false,
-		openFile: async () => null,
-		writeFileToPath: async () => {},
-		readFileFromPath: async () => '',
-		pickDirectory: async () => null,
-		checkForUpdate: async () => null,
-		checkBetaUpdate: async () => null,
-		downloadUpdate: async () => false,
-		installUpdateAndRestart: async () => false,
-		relaunch: async () => {},
-		...overrides
-	};
-}
+import { createDesktopCapabilitiesMock } from './desktop-capabilities.fixture';
 
 describe('createForcedBackup', () => {
 	it('writes to the configured backup directory and records success', async () => {
@@ -27,12 +8,12 @@ describe('createForcedBackup', () => {
 		const readFileFromPath = vi.fn(async () => '{"ok":true}');
 		const onSuccess = vi.fn(async () => {});
 
-		const result = await createForcedBackup({
-			desktop: makeDesktop({ writeFileToPath, readFileFromPath }),
-			getBackupContent: () => '{"ok":true}',
-			getAutoBackupDirectory: () => '/backups',
-			onSuccess
-		});
+			const result = await createForcedBackup({
+				desktop: createDesktopCapabilitiesMock({ writeFileToPath, readFileFromPath }).desktop,
+				getBackupContent: () => '{"ok":true}',
+				getAutoBackupDirectory: () => '/backups',
+				onSuccess
+			});
 
 		expect(result.ok).toBe(true);
 		expect(writeFileToPath).toHaveBeenCalledOnce();
@@ -46,11 +27,11 @@ describe('createForcedBackup', () => {
 	it('opens a save dialog when no backup directory is configured', async () => {
 		const saveFile = vi.fn(async (_filename: string, _content: string, _filters?: { name: string; extensions: string[] }[]) => true);
 
-		const result = await createForcedBackup({
-			desktop: makeDesktop({ saveFile }),
-			getBackupContent: () => '{"ok":true}',
-			getAutoBackupDirectory: () => null
-		});
+			const result = await createForcedBackup({
+				desktop: createDesktopCapabilitiesMock({ saveFile }).desktop,
+				getBackupContent: () => '{"ok":true}',
+				getAutoBackupDirectory: () => null
+			});
 
 		expect(result.ok).toBe(true);
 		expect(saveFile).toHaveBeenCalledOnce();
@@ -61,11 +42,11 @@ describe('createForcedBackup', () => {
 	});
 
 	it('blocks when the user cancels the save dialog', async () => {
-		const result = await createForcedBackup({
-			desktop: makeDesktop({ saveFile: async () => false }),
-			getBackupContent: () => '{"ok":true}',
-			getAutoBackupDirectory: () => null
-		});
+			const result = await createForcedBackup({
+				desktop: createDesktopCapabilitiesMock({ saveFile: async () => false }).desktop,
+				getBackupContent: () => '{"ok":true}',
+				getAutoBackupDirectory: () => null
+			});
 
 		expect(result).toEqual({
 			ok: false,
@@ -74,15 +55,15 @@ describe('createForcedBackup', () => {
 	});
 
 	it('blocks when writing the backup fails', async () => {
-		const result = await createForcedBackup({
-			desktop: makeDesktop({
-				writeFileToPath: async () => {
-					throw new Error('disk full');
-				}
-			}),
-			getBackupContent: () => '{"ok":true}',
-			getAutoBackupDirectory: () => '/backups'
-		});
+			const result = await createForcedBackup({
+				desktop: createDesktopCapabilitiesMock({
+					writeFileToPath: async () => {
+						throw new Error('disk full');
+					}
+				}).desktop,
+				getBackupContent: () => '{"ok":true}',
+				getAutoBackupDirectory: () => '/backups'
+			});
 
 		expect(result).toEqual({
 			ok: false,
@@ -93,14 +74,14 @@ describe('createForcedBackup', () => {
 	it('does not record success when backup verification fails', async () => {
 		const onSuccess = vi.fn(async () => {});
 
-		const result = await createForcedBackup({
-			desktop: makeDesktop({
-				readFileFromPath: async () => '{"ok":false}'
-			}),
-			getBackupContent: () => '{"ok":true}',
-			getAutoBackupDirectory: () => '/backups',
-			onSuccess
-		});
+			const result = await createForcedBackup({
+				desktop: createDesktopCapabilitiesMock({
+					readFileFromPath: async () => '{"ok":false}'
+				}).desktop,
+				getBackupContent: () => '{"ok":true}',
+				getAutoBackupDirectory: () => '/backups',
+				onSuccess
+			});
 
 		expect(result).toEqual({
 			ok: false,

--- a/tests/unit/in-memory-db.ts
+++ b/tests/unit/in-memory-db.ts
@@ -104,6 +104,10 @@ export function createInMemoryDb(): Database & {
 		if (eqMatch) {
 			return { match: row[eqMatch[1]] === params[paramOffset], consumed: 1 };
 		}
+		const literalEqMatch = whereClause.match(/^(\w+)\s*=\s*'([^']*)'$/);
+		if (literalEqMatch) {
+			return { match: row[literalEqMatch[1]] === literalEqMatch[2], consumed: 0 };
+		}
 		// Fallback: treat as always matching (for MAX queries etc.)
 		return { match: true, consumed: 0 };
 	}
@@ -206,8 +210,11 @@ export function createInMemoryDb(): Database & {
 				if (!rows) throw new Error(`Table ${upd.table} does not exist`);
 				let paramIdx = 0;
 				const setOps = upd.sets.map((s) => {
-					const [col] = s.split('=').map((p) => p.trim());
-					return { col, paramIndex: paramIdx++ };
+					const [col, expression] = s.split('=').map((p) => p.trim());
+					if (expression === '?') {
+						return { col, paramIndex: paramIdx++, sourceColumn: null };
+					}
+					return { col, paramIndex: null, sourceColumn: expression };
 				});
 				const whereParamOffset = paramIdx;
 				for (const row of rows) {
@@ -216,7 +223,8 @@ export function createInMemoryDb(): Database & {
 						if (!match) continue;
 					}
 					for (const op of setOps) {
-						row[op.col] = params[op.paramIndex];
+						row[op.col] =
+							op.paramIndex === null ? row[op.sourceColumn as string] : params[op.paramIndex];
 					}
 				}
 				return;

--- a/tests/unit/merge-customers-use-case.test.ts
+++ b/tests/unit/merge-customers-use-case.test.ts
@@ -96,6 +96,7 @@ describe('MergeCustomersUseCases', () => {
 					firstCellId: 'c1',
 					name: 'John Smith',
 					rvType: '',
+					eta: '',
 					phoneNumber: '555-1234',
 					notes: '',
 					startDate: '2025-07-01',
@@ -103,6 +104,7 @@ describe('MergeCustomersUseCases', () => {
 					parkingLocation: 'A1',
 					color: 'blue',
 					status: 'reserved',
+					createdAt: '2025-06-01T00:00:00.000Z',
 					customerId: 'a'
 				}
 			]);
@@ -137,13 +139,15 @@ describe('MergeCustomersUseCases', () => {
 					firstCellId: 'c1',
 					name: 'John Smith',
 					rvType: '',
+					eta: '',
 					phoneNumber: '555-1234',
 					notes: '',
 					startDate: '2025-07-01',
 					endDate: '2025-07-05',
 					parkingLocation: 'A1',
 					color: 'blue',
-					status: 'reserved'
+					status: 'reserved',
+					createdAt: '2025-06-01T00:00:00.000Z'
 					// no customerId
 				}
 			]);
@@ -168,6 +172,7 @@ describe('MergeCustomersUseCases', () => {
 					firstCellId: 'c1',
 					name: 'Other Person',
 					rvType: '',
+					eta: '',
 					phoneNumber: '999-9999',
 					notes: '',
 					startDate: '2025-07-01',
@@ -175,6 +180,7 @@ describe('MergeCustomersUseCases', () => {
 					parkingLocation: 'A1',
 					color: 'blue',
 					status: 'reserved',
+					createdAt: '2025-06-01T00:00:00.000Z',
 					customerId: 'other-id'
 				}
 			]);
@@ -265,6 +271,7 @@ describe('MergeCustomersUseCases', () => {
 					firstCellId: 'c1',
 					name: 'Alice',
 					rvType: '',
+					eta: '',
 					phoneNumber: '111',
 					notes: '',
 					startDate: '2025-07-01',
@@ -272,6 +279,7 @@ describe('MergeCustomersUseCases', () => {
 					parkingLocation: 'A1',
 					color: 'blue',
 					status: 'reserved',
+					createdAt: '2025-06-01T00:00:00.000Z',
 					customerId: 'a1'
 				}
 			]);

--- a/tests/unit/migrator.test.ts
+++ b/tests/unit/migrator.test.ts
@@ -8,13 +8,17 @@ describe('runMigrations', () => {
 		const db = createInMemoryDb();
 		const version = await runMigrations(db, allMigrations);
 
-		expect(version).toBe(5);
+		expect(version).toBe(6);
 		expect(db.tables.has('schema_migrations')).toBe(true);
 		expect(db.tables.has('parking_locations')).toBe(true);
 		expect(db.tables.has('reservations')).toBe(true);
 		expect(db.tables.has('app_metadata')).toBe(true);
 		expect(db.tables.has('admin_settings')).toBe(true);
 		expect(db.tables.has('customers')).toBe(true);
+		const reservationColumns = await db.select<{ name: string }>('PRAGMA table_info(reservations)');
+		expect(reservationColumns.map((column) => column.name)).toEqual(
+			expect.arrayContaining(['rv_type', 'eta', 'created_at', 'customer_id'])
+		);
 	});
 
 	it('records the migration version in schema_migrations', async () => {
@@ -22,12 +26,8 @@ describe('runMigrations', () => {
 		await runMigrations(db, allMigrations);
 
 		const rows = await db.select<{ version: number }>('SELECT * FROM schema_migrations');
-		expect(rows).toHaveLength(5);
-		expect(rows[0].version).toBe(1);
-		expect(rows[1].version).toBe(2);
-		expect(rows[2].version).toBe(3);
-		expect(rows[3].version).toBe(4);
-		expect(rows[4].version).toBe(5);
+		expect(rows).toHaveLength(6);
+		expect(rows.map((row) => row.version)).toEqual([1, 2, 3, 4, 5, 6]);
 	});
 
 	it('is idempotent — re-running does not re-apply migrations', async () => {
@@ -35,9 +35,9 @@ describe('runMigrations', () => {
 		await runMigrations(db, allMigrations);
 		const version2 = await runMigrations(db, allMigrations);
 
-		expect(version2).toBe(5);
+		expect(version2).toBe(6);
 		const rows = await db.select<{ version: number }>('SELECT * FROM schema_migrations');
-		expect(rows).toHaveLength(5);
+		expect(rows).toHaveLength(6);
 	});
 
 	it('applies only new migrations when database is partially migrated', async () => {

--- a/tests/unit/parking-location-use-cases.test.ts
+++ b/tests/unit/parking-location-use-cases.test.ts
@@ -46,8 +46,8 @@ describe('reorder', () => {
 		const data = baseData({
 			reservations: [{
 				index: 1, firstCellId: 'A-01|2026-03-01', name: 'Test',
-				rvType: '', phoneNumber: '', notes: '', startDate: '2026-03-01', endDate: '2026-03-02',
-				parkingLocation: 'A-01', color: 'blue', status: 'reserved'
+				rvType: '', eta: '', phoneNumber: '', notes: '', startDate: '2026-03-01', endDate: '2026-03-02',
+				parkingLocation: 'A-01', color: 'blue', status: 'reserved', createdAt: '2026-02-01T00:00:00.000Z'
 			}]
 		});
 		const result = useCases.reorder(['B-01', 'A-02', 'A-01'], data);

--- a/tests/unit/release-guard.test.ts
+++ b/tests/unit/release-guard.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 const execFileAsync = promisify(execFile);
 
 const scriptPath = 'scripts/release-guard.mjs';
+const stableConsent = 'I consent to publish stable release v1.19.4';
 
 function release(overrides: Record<string, unknown> = {}) {
 	return {
@@ -19,19 +20,20 @@ function release(overrides: Record<string, unknown> = {}) {
 	};
 }
 
-async function runGuard(tag: string, releases: unknown[] = []) {
+async function runGuard(tag: string, releases: unknown[] = [], consent = '') {
 	return await execFileAsync('node', [scriptPath, '--tag', tag], {
 		cwd: process.cwd(),
 		env: {
 			...process.env,
-			RELEASE_GUARD_RELEASES_JSON: JSON.stringify(releases)
+			RELEASE_GUARD_RELEASES_JSON: JSON.stringify(releases),
+			RELEASE_GUARD_STABLE_RELEASE_CONSENT: consent
 		}
 	});
 }
 
-async function expectGuardFailure(tag: string, releases: unknown[] = []) {
+async function expectGuardFailure(tag: string, releases: unknown[] = [], consent = '') {
 	try {
-		await runGuard(tag, releases);
+		await runGuard(tag, releases, consent);
 		throw new Error('Expected release guard to fail');
 	} catch (error) {
 		if (error instanceof Error && error.message === 'Expected release guard to fail') {
@@ -48,28 +50,58 @@ describe('release guard', () => {
 		expect(stdout).toContain('does not require prior beta verification');
 	});
 
-	it('allows stable tags when a published matching beta has macOS and Windows assets', async () => {
-		const { stdout } = await runGuard('v1.19.4', [release()]);
+	it('rejects unsupported release tag formats', async () => {
+		const error = await expectGuardFailure('v1.19.4-hotfix.1');
 
+		expect(error.stderr).toContain('Unsupported release tag v1.19.4-hotfix.1');
+	});
+
+	it('allows stable tags when exact consent is present and a published matching beta has macOS and Windows assets', async () => {
+		const { stdout } = await runGuard('v1.19.4', [release()], stableConsent);
+
+		expect(stdout).toContain('Stable release consent verified for v1.19.4');
 		expect(stdout).toContain('Found qualifying beta prerelease v1.19.4-beta.1');
 	});
 
+	it('rejects stable tags without exact consent', async () => {
+		const error = await expectGuardFailure('v1.19.4', [release()]);
+
+		expect(error.stderr).toContain('Explicit consent is required before publishing stable release v1.19.4');
+		expect(error.stderr).toContain('I consent to publish stable release v1.19.4');
+	});
+
+	it('rejects stable tags with stale consent for a different version', async () => {
+		const error = await expectGuardFailure(
+			'v1.19.4',
+			[release()],
+			'I consent to publish stable release v1.19.3'
+		);
+
+		expect(error.stderr).toContain('Explicit consent is required before publishing stable release v1.19.4');
+	});
+
 	it('rejects stable tags without a matching beta prerelease', async () => {
-		const error = await expectGuardFailure('v1.19.4', [release({ tag_name: 'v1.19.3-beta.1' })]);
+		const error = await expectGuardFailure(
+			'v1.19.4',
+			[release({ tag_name: 'v1.19.3-beta.1' })],
+			stableConsent
+		);
 
 		expect(error.stderr).toContain('No qualifying beta prerelease found for v1.19.4');
 	});
 
 	it('rejects draft beta releases because they were not published for testing', async () => {
-		const error = await expectGuardFailure('v1.19.4', [release({ draft: true })]);
+		const error = await expectGuardFailure('v1.19.4', [release({ draft: true })], stableConsent);
 
 		expect(error.stderr).toContain('No qualifying beta prerelease found for v1.19.4');
 	});
 
 	it('rejects beta releases that do not include both desktop platform artifacts', async () => {
-		const error = await expectGuardFailure('v1.19.4', [
-			release({ assets: [{ name: 'RV Reservation System_1.19.4_universal.dmg' }] })
-		]);
+		const error = await expectGuardFailure(
+			'v1.19.4',
+			[release({ assets: [{ name: 'RV Reservation System_1.19.4_universal.dmg' }] })],
+			stableConsent
+		);
 
 		expect(error.stderr).toContain('No qualifying beta prerelease found for v1.19.4');
 	});

--- a/tests/unit/reservation-active-count.test.ts
+++ b/tests/unit/reservation-active-count.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { countCurrentAndFutureReservations } from '$lib/domain/reservations';
+import type { Reservation } from '$lib/types';
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+	return {
+		index: 1,
+		firstCellId: 'A-01::2026-05-01',
+		name: 'Test Guest',
+		rvType: '',
+		eta: '',
+		phoneNumber: '',
+		notes: '',
+		startDate: '2026-05-01',
+		endDate: '2026-05-05',
+		parkingLocation: 'A-01',
+		color: 'blue',
+		status: 'reserved',
+		createdAt: '2026-04-01T00:00:00.000Z',
+		...overrides
+	};
+}
+
+describe('countCurrentAndFutureReservations', () => {
+	it('counts reservations that have not fully checked out', () => {
+		const reservations = [
+			makeReservation({ index: 1, endDate: '2026-05-22' }),
+			makeReservation({ index: 2, endDate: '2026-05-23' }),
+			makeReservation({ index: 3, endDate: '2026-05-24' })
+		];
+
+		expect(countCurrentAndFutureReservations(reservations, '2026-05-23')).toBe(2);
+	});
+
+	it('updates when the supplied today date advances', () => {
+		const reservations = [
+			makeReservation({ index: 1, endDate: '2026-05-23' }),
+			makeReservation({ index: 2, endDate: '2026-05-24' })
+		];
+
+		expect(countCurrentAndFutureReservations(reservations, '2026-05-23')).toBe(2);
+		expect(countCurrentAndFutureReservations(reservations, '2026-05-24')).toBe(1);
+	});
+});

--- a/tests/unit/reservation-use-cases.test.ts
+++ b/tests/unit/reservation-use-cases.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { createReservationUseCases } from '$lib/application/use-cases/reservation-use-cases';
 import { buildFirstCellId } from '$lib/domain/reservations';
 import type { AppDataRepository } from '$lib/application/ports';
@@ -28,6 +28,7 @@ function makeForm(overrides: Partial<ReservationFormValues> = {}): ReservationFo
 	return {
 		name: 'Test Guest',
 		rvType: '',
+		eta: '',
 		phoneNumber: '555-1234',
 		notes: '',
 		startDate: '2025-06-01',
@@ -40,6 +41,58 @@ function makeForm(overrides: Partial<ReservationFormValues> = {}): ReservationFo
 }
 
 describe('ReservationUseCases', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe('reservation details', () => {
+		it('records ETA and creation timestamp on new reservations', () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-05-20T15:30:00.000Z'));
+			const useCases = createReservationUseCases(createFakeRepo());
+
+			const result = useCases.save(makeForm({ eta: '2 PM' }), makeAppData());
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.data!.reservations[0].eta).toBe('2 PM');
+				expect(result.data!.reservations[0].createdAt).toBe('2026-05-20T15:30:00.000Z');
+			}
+		});
+
+		it('preserves creation timestamp when editing a reservation', () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-06-01T12:00:00.000Z'));
+			const useCases = createReservationUseCases(createFakeRepo());
+			const data = makeAppData({
+				reservations: [{
+					index: 1,
+					firstCellId: buildFirstCellId('A-01', '2025-06-01'),
+					name: 'Test Guest',
+					rvType: 'Class A',
+					eta: '1 PM',
+					phoneNumber: '555-1234',
+					notes: '',
+					startDate: '2025-06-01',
+					endDate: '2025-06-03',
+					parkingLocation: 'A-01',
+					color: 'blue',
+					status: 'reserved',
+					createdAt: '2025-01-15T08:00:00.000Z'
+				}],
+				nextReservationIndex: 2
+			});
+
+			const result = useCases.save(makeForm({ index: 1, eta: '3 PM' }), data);
+
+			expect(result.ok).toBe(true);
+			if (result.ok) {
+				expect(result.data!.reservations[0].eta).toBe('3 PM');
+				expect(result.data!.reservations[0].createdAt).toBe('2025-01-15T08:00:00.000Z');
+			}
+		});
+	});
+
 	describe('customerId round-trip', () => {
 		it('persists customerId on new reservation', () => {
 			const useCases = createReservationUseCases(createFakeRepo());
@@ -61,6 +114,7 @@ describe('ReservationUseCases', () => {
 					firstCellId: buildFirstCellId('A-01', '2025-06-01'),
 					name: 'Test Guest',
 					rvType: '',
+					eta: '',
 					phoneNumber: '555-1234',
 					notes: '',
 					startDate: '2025-06-01',
@@ -68,6 +122,7 @@ describe('ReservationUseCases', () => {
 					parkingLocation: 'A-01',
 					color: 'blue',
 					status: 'reserved',
+					createdAt: '2025-01-01T00:00:00.000Z',
 					customerId: 'cust-123'
 				}],
 				nextReservationIndex: 2
@@ -104,13 +159,15 @@ describe('ReservationUseCases', () => {
 					firstCellId: buildFirstCellId('A-01', '2025-06-10'),
 					name: 'Move Guest',
 					rvType: '',
+					eta: '',
 					phoneNumber: '',
 					notes: '',
 					startDate: '2025-06-10',
 					endDate: '2025-06-13',
 					parkingLocation: 'A-01',
 					color: 'blue',
-					status: 'reserved'
+					status: 'reserved',
+					createdAt: '2025-01-01T00:00:00.000Z'
 				}],
 				nextReservationIndex: 2,
 				...overrides
@@ -163,26 +220,30 @@ describe('ReservationUseCases', () => {
 						firstCellId: buildFirstCellId('A-01', '2025-06-10'),
 						name: 'Move Guest',
 						rvType: '',
+						eta: '',
 						phoneNumber: '',
 						notes: '',
 						startDate: '2025-06-10',
 						endDate: '2025-06-13',
 						parkingLocation: 'A-01',
 						color: 'blue',
-						status: 'reserved'
+						status: 'reserved',
+						createdAt: '2025-01-01T00:00:00.000Z'
 					},
 					{
 						index: 2,
 						firstCellId: buildFirstCellId('A-01', '2025-06-15'),
 						name: 'Blocking Guest',
 						rvType: '',
+						eta: '',
 						phoneNumber: '',
 						notes: '',
 						startDate: '2025-06-15',
 						endDate: '2025-06-18',
 						parkingLocation: 'A-01',
 						color: 'green',
-						status: 'reserved'
+						status: 'reserved',
+						createdAt: '2025-01-02T00:00:00.000Z'
 					}
 				],
 				nextReservationIndex: 3

--- a/tests/unit/restore-backup.test.ts
+++ b/tests/unit/restore-backup.test.ts
@@ -25,13 +25,15 @@ function makeAppData(overrides: Partial<PersistedAppData> = {}): PersistedAppDat
 			firstCellId: 'A-01::2025-06-01',
 			name: 'Original Guest',
 			rvType: '',
+			eta: '',
 			phoneNumber: '555-1234',
 			notes: '',
 			startDate: '2025-06-01',
 			endDate: '2025-06-05',
 			parkingLocation: 'A-01',
 			color: 'blue',
-			status: 'reserved'
+			status: 'reserved',
+			createdAt: '2025-05-01T00:00:00.000Z'
 		}],
 		parkingLocations: ['A-01', 'B-01'],
 		nextReservationIndex: 2,
@@ -56,13 +58,15 @@ function makeInput(overrides: Partial<RestoreInput> = {}): RestoreInput {
 			firstCellId: 'C-01::2025-07-01',
 			name: 'Backup Guest',
 			rvType: '',
+			eta: '',
 			phoneNumber: '555-9999',
 			notes: '',
 			startDate: '2025-07-01',
 			endDate: '2025-07-05',
 			parkingLocation: 'C-01',
 			color: 'green',
-			status: 'reserved'
+			status: 'reserved',
+			createdAt: '2025-06-01T00:00:00.000Z'
 		}],
 		parkingLocations: ['C-01'],
 		nextReservationIndex: 11,

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -8,6 +8,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		firstCellId: 'A|2025-06-01',
 		name: 'John Smith',
 		rvType: '',
+		eta: '',
 		phoneNumber: '555-1234',
 		notes: '',
 		startDate: '2025-06-01',
@@ -15,6 +16,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		parkingLocation: 'Site A',
 		color: 'blue',
 		status: 'reserved',
+		createdAt: '2025-05-01T00:00:00.000Z',
 		...overrides
 	};
 }

--- a/tests/unit/sqlite-repositories.test.ts
+++ b/tests/unit/sqlite-repositories.test.ts
@@ -23,6 +23,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		firstCellId: 'A-01::2025-03-01',
 		name: 'Test Guest',
 		rvType: '',
+		eta: '',
 		phoneNumber: '555-1234',
 		notes: 'Some notes',
 		startDate: '2025-03-01',
@@ -30,6 +31,7 @@ function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
 		parkingLocation: 'A-01',
 		color: 'blue',
 		status: 'reserved',
+		createdAt: '2025-02-01T00:00:00.000Z',
 		...overrides
 	};
 }
@@ -150,6 +152,8 @@ describe('SQLite AppDataRepository', () => {
 
 		expect(loaded.reservations).toHaveLength(2);
 		expect(loaded.reservations[0].name).toBe('Test Guest');
+		expect(loaded.reservations[0].createdAt).toBe('2025-02-01T00:00:00.000Z');
+		expect(loaded.reservations[0].eta).toBe('');
 		expect(loaded.reservations[1].name).toBe('Another Guest');
 		expect(loaded.parkingLocations).toEqual(['A-01', 'B-01']);
 		expect(loaded.nextReservationIndex).toBe(3);

--- a/tests/unit/status-migration.test.ts
+++ b/tests/unit/status-migration.test.ts
@@ -187,4 +187,18 @@ describe('storage migration (sanitizeReservation)', () => {
 		expect(result).not.toBeNull();
 		expect(result!.status).toBe('reserved');
 	});
+
+	it('defaults missing creation timestamp to the reservation start date', () => {
+		const result = sanitizeReservation(validBase);
+
+		expect(result).not.toBeNull();
+		expect(result!.createdAt).toBe('2026-03-01');
+	});
+
+	it('preserves ETA from stored reservations', () => {
+		const result = sanitizeReservation({ ...validBase, eta: '2:30 PM' });
+
+		expect(result).not.toBeNull();
+		expect(result!.eta).toBe('2:30 PM');
+	});
 });

--- a/tests/unit/update-checker.test.ts
+++ b/tests/unit/update-checker.test.ts
@@ -11,6 +11,7 @@ function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapab
 		saveFile: async () => false,
 		openFile: async () => null,
 		writeFileToPath: async () => {},
+		readFileFromPath: async () => '',
 		pickDirectory: async () => null,
 		checkForUpdate: async () => null,
 		checkBetaUpdate: async () => null,

--- a/tests/unit/update-checker.test.ts
+++ b/tests/unit/update-checker.test.ts
@@ -2,24 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { createUpdateChecker } from '$lib/app/update-checker';
 import type { DesktopCapabilities, UpdateInfo } from '$lib/application/ports';
+import { createDesktopCapabilitiesMock } from './desktop-capabilities.fixture';
 
-function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapabilities {
-	return {
-		isDesktop: true,
-		getAppDataDir: async () => null,
-		getVersion: async () => null,
-		saveFile: async () => false,
-		openFile: async () => null,
-		writeFileToPath: async () => {},
-		readFileFromPath: async () => '',
-		pickDirectory: async () => null,
-		checkForUpdate: async () => null,
-		checkBetaUpdate: async () => null,
-		downloadUpdate: async () => false,
-		installUpdateAndRestart: async () => false,
-		relaunch: async () => {},
-		...overrides
-	};
+function makeDesktop(overrides: Partial<DesktopCapabilities> = {}) {
+	return createDesktopCapabilitiesMock(overrides).desktop;
 }
 
 const fakeUpdate: UpdateInfo = {

--- a/tests/unit/verified-backup.test.ts
+++ b/tests/unit/verified-backup.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
+import type { DesktopCapabilities } from '$lib/application/ports';
+
+function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapabilities {
+	const files = new Map<string, string>();
+	return {
+		isDesktop: true,
+		getAppDataDir: async () => null,
+		getVersion: async () => null,
+		saveFile: async () => false,
+		openFile: async () => null,
+		writeFileToPath: async (path: string, content: string) => {
+			files.set(path, content);
+		},
+		readFileFromPath: async (path: string) => files.get(path) ?? '',
+		pickDirectory: async () => null,
+		checkForUpdate: async () => null,
+		checkBetaUpdate: async () => null,
+		downloadUpdate: async () => false,
+		installUpdateAndRestart: async () => false,
+		relaunch: async () => {},
+		...overrides
+	};
+}
+
+describe('writeVerifiedBackupToDirectory', () => {
+	it('writes backup content and verifies it by reading the file back', async () => {
+		const writeFileToPath = vi.fn(async () => {});
+		const readFileFromPath = vi.fn(async () => '{"ok":true}');
+
+		const result = await writeVerifiedBackupToDirectory({
+			desktop: makeDesktop({ writeFileToPath, readFileFromPath }),
+			directoryPath: '/backups',
+			getBackupContent: () => '{"ok":true}',
+			now: () => new Date('2026-05-04T12:00:00.000Z')
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error(result.error);
+		expect(result.timestamp).toBe('2026-05-04T12:00:00.000Z');
+		expect(result.filePath).toMatch(/^\/backups\/rv-backup-\d{4}-\d{2}-\d{2}-\d{6}\.json$/);
+		expect(writeFileToPath).toHaveBeenCalledWith(result.filePath, '{"ok":true}');
+		expect(readFileFromPath).toHaveBeenCalledWith(result.filePath);
+	});
+
+	it('fails when writing throws', async () => {
+		const result = await writeVerifiedBackupToDirectory({
+			desktop: makeDesktop({
+				writeFileToPath: async () => {
+					throw new Error('disk full');
+				}
+			}),
+			directoryPath: '/backups',
+			getBackupContent: () => '{"ok":true}'
+		});
+
+		expect(result).toEqual({ ok: false, error: 'Backup failed: disk full' });
+	});
+
+	it('fails when read-back content differs from generated content', async () => {
+		const result = await writeVerifiedBackupToDirectory({
+			desktop: makeDesktop({
+				readFileFromPath: async () => '{"ok":false}'
+			}),
+			directoryPath: '/backups',
+			getBackupContent: () => '{"ok":true}'
+		});
+
+		expect(result).toEqual({
+			ok: false,
+			error: 'Backup verification failed: written file contents did not match generated backup.'
+		});
+	});
+
+	it('preserves existing trailing path separators', async () => {
+		const paths: string[] = [];
+
+		const result = await writeVerifiedBackupToDirectory({
+			desktop: makeDesktop({
+				writeFileToPath: async (path, _content) => {
+					paths.push(path);
+				},
+				readFileFromPath: async () => '{"ok":true}'
+			}),
+			directoryPath: '/backups/',
+			getBackupContent: () => '{"ok":true}'
+		});
+
+		expect(result.ok).toBe(true);
+		expect(paths[0]).toMatch(/^\/backups\/rv-backup-/);
+		expect(paths[0]).not.toContain('//');
+	});
+});

--- a/tests/unit/verified-backup.test.ts
+++ b/tests/unit/verified-backup.test.ts
@@ -1,36 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { writeVerifiedBackupToDirectory } from '$lib/app/verified-backup';
-import type { DesktopCapabilities } from '$lib/application/ports';
+import { createDesktopCapabilitiesMock } from './desktop-capabilities.fixture';
 
-function makeDesktop(overrides: Partial<DesktopCapabilities> = {}): DesktopCapabilities {
-	const files = new Map<string, string>();
-	return {
-		isDesktop: true,
-		getAppDataDir: async () => null,
-		getVersion: async () => null,
-		saveFile: async () => false,
-		openFile: async () => null,
-		writeFileToPath: async (path: string, content: string) => {
-			files.set(path, content);
-		},
-		readFileFromPath: async (path: string) => files.get(path) ?? '',
-		pickDirectory: async () => null,
-		checkForUpdate: async () => null,
-		checkBetaUpdate: async () => null,
-		downloadUpdate: async () => false,
-		installUpdateAndRestart: async () => false,
-		relaunch: async () => {},
-		...overrides
-	};
-}
-
-describe('writeVerifiedBackupToDirectory', () => {
-	it('writes backup content and verifies it by reading the file back', async () => {
-		const writeFileToPath = vi.fn(async () => {});
-		const readFileFromPath = vi.fn(async () => '{"ok":true}');
+	describe('writeVerifiedBackupToDirectory', () => {
+		it('writes backup content and verifies it by reading the file back', async () => {
+			const writeFileToPath = vi.fn(async (_path: string, _content: string) => {});
+			const readFileFromPath = vi.fn(async (_path: string) => '{"ok":true}');
 
 		const result = await writeVerifiedBackupToDirectory({
-			desktop: makeDesktop({ writeFileToPath, readFileFromPath }),
+			desktop: createDesktopCapabilitiesMock({ writeFileToPath, readFileFromPath }).desktop,
 			directoryPath: '/backups',
 			getBackupContent: () => '{"ok":true}',
 			now: () => new Date('2026-05-04T12:00:00.000Z')
@@ -39,18 +17,19 @@ describe('writeVerifiedBackupToDirectory', () => {
 		expect(result.ok).toBe(true);
 		if (!result.ok) throw new Error(result.error);
 		expect(result.timestamp).toBe('2026-05-04T12:00:00.000Z');
-		expect(result.filePath).toMatch(/^\/backups\/rv-backup-\d{4}-\d{2}-\d{2}-\d{6}\.json$/);
-		expect(writeFileToPath).toHaveBeenCalledWith(result.filePath, '{"ok":true}');
-		expect(readFileFromPath).toHaveBeenCalledWith(result.filePath);
+		const [filePath] = writeFileToPath.mock.calls[0];
+		expect(filePath).toMatch(/^\/backups\/rv-backup-\d{4}-\d{2}-\d{2}-\d{6}\.json$/);
+		expect(writeFileToPath).toHaveBeenCalledWith(filePath, '{"ok":true}');
+		expect(readFileFromPath).toHaveBeenCalledWith(filePath);
 	});
 
 	it('fails when writing throws', async () => {
 		const result = await writeVerifiedBackupToDirectory({
-			desktop: makeDesktop({
+			desktop: createDesktopCapabilitiesMock({
 				writeFileToPath: async () => {
 					throw new Error('disk full');
 				}
-			}),
+			}).desktop,
 			directoryPath: '/backups',
 			getBackupContent: () => '{"ok":true}'
 		});
@@ -60,9 +39,9 @@ describe('writeVerifiedBackupToDirectory', () => {
 
 	it('fails when read-back content differs from generated content', async () => {
 		const result = await writeVerifiedBackupToDirectory({
-			desktop: makeDesktop({
+			desktop: createDesktopCapabilitiesMock({
 				readFileFromPath: async () => '{"ok":false}'
-			}),
+			}).desktop,
 			directoryPath: '/backups',
 			getBackupContent: () => '{"ok":true}'
 		});
@@ -77,12 +56,12 @@ describe('writeVerifiedBackupToDirectory', () => {
 		const paths: string[] = [];
 
 		const result = await writeVerifiedBackupToDirectory({
-			desktop: makeDesktop({
+			desktop: createDesktopCapabilitiesMock({
 				writeFileToPath: async (path, _content) => {
 					paths.push(path);
 				},
 				readFileFromPath: async () => '{"ok":true}'
-			}),
+			}).desktop,
 			directoryPath: '/backups/',
 			getBackupContent: () => '{"ok":true}'
 		});


### PR DESCRIPTION
## Summary
- Adds a desktop-only Backup Now button to the Automatic Backup settings panel.
- Verifies directory-based backups by reading the file back and comparing exact JSON content.
- Reuses verified writes for scheduled auto-backups and pre-update forced backups.

## Validation
- npm run code-health:changed
- npm run code-health:full
- npm run check
- npm run build
- npm run test:unit
- npm run test:e2e -- tests/e2e/admin.spec.ts -g "Automatic backup manual trigger"

## Screenshots
- screenshots/manual-auto-backup-baseline.png
- screenshots/manual-auto-backup-after.png